### PR TITLE
Add additional testing and resolve issues.

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -819,7 +819,7 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
     _Tp __b = __z.imag();
     _Tp __c = __w.real();
     _Tp __d = __w.imag();
-    _Tp __logbw = sycl::logb(fmax(sycl::fabs(__c), sycl::fabs(__d)));
+    _Tp __logbw = sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
     if (sycl::isfinite(__logbw))
     {
         __ilogbw = static_cast<int>(__logbw);

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -244,9 +244,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 #include <complex>
 #include <type_traits>
 #include <sycl/sycl.hpp>
-#if !defined(_SYCL_EXT_CPLX_HAS_NO_LOCALIZATION)
-#   include <sstream> // for std::basic_ostringstream
-#endif
+#include <sstream> // for std::basic_ostringstream
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
 
@@ -1579,7 +1577,6 @@ operator>>(basic_istream<_CharT, _Traits>& __is, complex<_Tp>& __x)
     return __is;
 }
 
-#if !defined(_SYCL_EXT_CPLX_HAS_NO_LOCALIZATION)
 template<class _Tp, class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
@@ -1591,7 +1588,6 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
     __s << '(' << __x.real() << ',' << __x.imag() << ')';
     return __os << __s.str();
 }
-#endif // !_SYCL_EXT_CPLX_HAS_NO_LOCALIZATION
 
 template<class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -1591,7 +1591,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
 
 template<class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-inline const sycl::stream &operator<<(const sycl::stream & __ss, const complex<_Tp>& _x) {
+const sycl::stream &operator<<(const sycl::stream & __ss, const complex<_Tp>& _x) {
   return __ss << "(" << _x.real() << "," << _x.imag() << ")";
 }
 

--- a/tests/acos_complex.cpp
+++ b/tests/acos_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_acos {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/acosh_complex.cpp
+++ b/tests/acosh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_acosh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/asin_complex.cpp
+++ b/tests/asin_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_asin {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/asinh_complex.cpp
+++ b/tests/asinh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_asinh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/atan_complex.cpp
+++ b/tests/atan_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_atan {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/atanh_complex.cpp
+++ b/tests/atanh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_atanh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/cos_complex.cpp
+++ b/tests/cos_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_cos {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/cosh_complex.cpp
+++ b/tests/cosh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_cosh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/exp_complex.cpp
+++ b/tests/exp_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_exp {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/log10_complex.cpp
+++ b/tests/log10_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_log10 {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/log_complex.cpp
+++ b/tests/log_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_log {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/pow_complex.cpp
+++ b/tests/pow_complex.cpp
@@ -27,6 +27,8 @@ bool test_pow_cplx_cplx(sycl::queue &Q, T init_re, T init_im) {
 
   pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+  sycl::free(cplx_out, Q);
+
   return pass;
 }
 

--- a/tests/sin_complex.cpp
+++ b/tests/sin_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_sin {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/sinh_complex.cpp
+++ b/tests/sinh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_sinh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/sqrt_complex.cpp
+++ b/tests/sqrt_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_sqrt {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/tan_complex.cpp
+++ b/tests/tan_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_tan {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/tanh_complex.cpp
+++ b/tests/tanh_complex.cpp
@@ -25,6 +25,8 @@ template <typename T> struct test_tanh {
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
+    sycl::free(cplx_out, Q);
+
     return pass;
   }
 };

--- a/tests/test_complex_types.cpp
+++ b/tests/test_complex_types.cpp
@@ -7,7 +7,7 @@ using namespace sycl::ext::cplx;
   template <typename T> struct test##_##op_name##_##types {                    \
     bool operator()() {                                                        \
       static_assert(                                                           \
-          std::is_same_v<complex<T>, decltype(declval<complex<T>>() +          \
+          std::is_same_v<complex<T>, decltype(declval<complex<T>>() op         \
                                               declval<complex<T>>())>);        \
       return true;                                                             \
     }                                                                          \

--- a/tests/test_operator_complex.cpp
+++ b/tests/test_operator_complex.cpp
@@ -26,6 +26,8 @@
                                                                                \
       pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
                                                                                \
+      sycl::free(cplx_out, Q);                                                 \
+                                                                               \
       return pass;                                                             \
     }                                                                          \
   };
@@ -69,6 +71,8 @@ test_op(test_div, /);
           cplx_inout[0], std::complex<T>(std_inout.real(), std_inout.imag()),  \
           /*is_device*/ false);                                                \
                                                                                \
+      sycl::free(cplx_inout, Q);                                               \
+                                                                               \
       return pass;                                                             \
     }                                                                          \
   };
@@ -84,7 +88,7 @@ int main() {
   sycl::queue Q;
 
   bool test_failed = false;
-  
+
   {
     bool test_passes = true;
     test_passes &= test_valid_types<test_add>(Q, 4.42, 2.02, -1.5, 3.2);

--- a/tests/test_operator_complex.cpp
+++ b/tests/test_operator_complex.cpp
@@ -82,7 +82,7 @@ test_op(test_div, /);
       pass &= check_results(                                                   \
           cplx_inout[0], std::complex<T>(std_inout.real(), std_inout.imag()),  \
           /*is_device*/ false);                                                \
-
+                                                                               \
       /* Check complex-decimal op */                                           \
       std_inout = init_std_complex(init_re2, init_im2);                        \
       cplx_inout[0].real(init_re2);                                            \

--- a/tests/test_stream_operator.cpp
+++ b/tests/test_stream_operator.cpp
@@ -1,8 +1,7 @@
 #include "test_helper.hpp"
 
-template <typename T>
-struct test_stream_operator {
-  bool operator() (sycl::queue &Q, T init_re, T init_im) {
+template <typename T> struct test_sycl_stream_operator {
+  bool operator()(sycl::queue &Q, T init_re, T init_im) {
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
     cplx_out[0] = sycl::ext::cplx::complex<T>(init_re, init_im);
 
@@ -17,14 +16,56 @@ struct test_stream_operator {
   }
 };
 
+// Host only tests for std::basic_ostream and std::basic_istream
+template <typename T> struct test_ostream_operator {
+  bool operator()(T init_re, T init_im) {
+    sycl::ext::cplx::complex<T> c(init_re, init_im);
+
+    std::ostringstream os;
+    os << c;
+
+    std::ostringstream ref_oss;
+    ref_oss << "(" << init_re << "," << init_im << ")";
+
+    if (ref_oss.str() == os.str())
+      return true;
+    return false;
+  }
+};
+
+template <typename T> struct test_istream_operator {
+  bool operator()(T init_re, T init_im) {
+    sycl::ext::cplx::complex<T> c(init_re, init_im);
+
+    std::ostringstream ref_oss;
+    ref_oss << "(" << init_re << "," << init_im << ")";
+
+    std::istringstream iss(ref_oss.str());
+
+    iss >> c;
+
+    return check_results(c, std::complex<T>(init_re, init_im),
+                         /*is_device*/ false);
+  }
+};
+
 int main() {
   sycl::queue Q;
 
   bool test_passes = true;
 
-  test_passes &= test_valid_types<test_stream_operator>(Q, 0.42, 0);
-  test_passes &= test_valid_types<test_stream_operator>(Q, INFINITY, INFINITY);
-  test_passes &= test_valid_types<test_stream_operator>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_sycl_stream_operator>(Q, 0.42, -1.1);
+  test_passes &=
+      test_valid_types<test_sycl_stream_operator>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_sycl_stream_operator>(Q, NAN, NAN);
+
+  test_passes &= test_valid_types<test_ostream_operator>(0.42, -1.1);
+  test_passes &= test_valid_types<test_ostream_operator>(INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_ostream_operator>(NAN, NAN);
+
+  test_passes &= test_valid_types<test_istream_operator>(0.42, -1.1);
+  test_passes &= test_valid_types<test_istream_operator>(INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_istream_operator>(NAN, NAN);
 
   if (!test_passes)
     std::cerr << "Stream operator with complex test fails\n";

--- a/tests/test_stream_operator.cpp
+++ b/tests/test_stream_operator.cpp
@@ -12,6 +12,8 @@ template <typename T> struct test_sycl_stream_operator {
       });
     });
 
+    sycl::free(cplx_out, Q);
+
     return true;
   }
 };

--- a/tests/test_stream_operator.cpp
+++ b/tests/test_stream_operator.cpp
@@ -27,7 +27,7 @@ template <typename T> struct test_ostream_operator {
     os << c;
 
     std::ostringstream ref_oss;
-    ref_oss << "(" << init_re << "," << init_im << ")";
+    ref_oss << std::complex<T>(init_re, init_im);
 
     if (ref_oss.str() == os.str())
       return true;


### PR DESCRIPTION
This PR adds a collection of simple changes. Most fix an issue, remove a redundant piece of code or update the testing.

Changes:
* Adds std c++ stream tests for the complex type, in `test_stream_operator`.
* Removes `_SYCL_EXT_CPLX_HAS_NO_LOCALIZATION` macro this appears to be from the libcxx implementation and it is not clear as to its use for SYCL. If needed SYCL implementers can add it back in.
* Fixes an type in the operator tests.
* Adds a missing `sycl::` to an fmax which takes two non-complex values as inputs.
* Frees shared memory in sycl tests
* Removes duplicate inline from `std::stream` operator