### PR TITLE
Add tests for abs, arg, norm, polar, and complex-scalar operators

### DIFF
--- a/tests/abs_complex.cpp
+++ b/tests/abs_complex.cpp
@@ -1,0 +1,57 @@
+#include "test_helper.hpp"
+
+template <typename T> struct test_abs {
+  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+    bool pass = true;
+
+    auto std_in = init_std_complex(init_re, init_im);
+    sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
+
+    T std_out{};
+    auto *cplx_out = sycl::malloc_shared<T>(1, Q);
+
+    // Get std::complex output
+    std_out = std::abs(std_in);
+
+    // Check cplx::complex output from device
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::abs<T>(cplx_input);
+     }).wait();
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+
+    // Check cplx::complex output from host
+    cplx_out[0] = sycl::ext::cplx::abs<T>(cplx_input);
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+
+    sycl::free(cplx_out, Q);
+
+    return pass;
+  }
+};
+
+int main() {
+  sycl::queue Q;
+
+  bool test_passes = true;
+  test_passes &= test_valid_types<test_abs>(Q, 4.42, 2.02);
+
+  test_passes &= test_valid_types<test_abs>(Q, INFINITY, 2.02);
+  test_passes &= test_valid_types<test_abs>(Q, 4.42, INFINITY);
+  test_passes &= test_valid_types<test_abs>(Q, INFINITY, INFINITY);
+
+  test_passes &= test_valid_types<test_abs>(Q, NAN, 2.02);
+  test_passes &= test_valid_types<test_abs>(Q, 4.42, NAN);
+  test_passes &= test_valid_types<test_abs>(Q, NAN, NAN);
+
+  test_passes &= test_valid_types<test_abs>(Q, NAN, INFINITY);
+  test_passes &= test_valid_types<test_abs>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_abs>(Q, NAN, INFINITY);
+  test_passes &= test_valid_types<test_abs>(Q, INFINITY, NAN);
+
+  if (!test_passes)
+    std::cerr << "acos complex test fails\n";
+
+  return !test_passes;
+}

--- a/tests/arg_complex.cpp
+++ b/tests/arg_complex.cpp
@@ -1,0 +1,57 @@
+#include "test_helper.hpp"
+
+template <typename T> struct test_arg {
+  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+    bool pass = true;
+
+    auto std_in = init_std_complex(init_re, init_im);
+    sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
+
+    T std_out{};
+    auto *cplx_out = sycl::malloc_shared<T>(1, Q);
+
+    // Get std::complex output
+    std_out = std::arg(std_in);
+
+    // Check cplx::complex output from device
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::arg<T>(cplx_input);
+     }).wait();
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+
+    // Check cplx::complex output from host
+    cplx_out[0] = sycl::ext::cplx::arg<T>(cplx_input);
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+
+    sycl::free(cplx_out, Q);
+
+    return pass;
+  }
+};
+
+int main() {
+  sycl::queue Q;
+
+  bool test_passes = true;
+  test_passes &= test_valid_types<test_arg>(Q, 4.42, 2.02);
+
+  test_passes &= test_valid_types<test_arg>(Q, INFINITY, 2.02);
+  test_passes &= test_valid_types<test_arg>(Q, 4.42, INFINITY);
+  test_passes &= test_valid_types<test_arg>(Q, INFINITY, INFINITY);
+
+  test_passes &= test_valid_types<test_arg>(Q, NAN, 2.02);
+  test_passes &= test_valid_types<test_arg>(Q, 4.42, NAN);
+  test_passes &= test_valid_types<test_arg>(Q, NAN, NAN);
+
+  test_passes &= test_valid_types<test_arg>(Q, NAN, INFINITY);
+  test_passes &= test_valid_types<test_arg>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_arg>(Q, NAN, INFINITY);
+  test_passes &= test_valid_types<test_arg>(Q, INFINITY, NAN);
+
+  if (!test_passes)
+    std::cerr << "acos complex test fails\n";
+
+  return !test_passes;
+}

--- a/tests/norm_complex.cpp
+++ b/tests/norm_complex.cpp
@@ -1,0 +1,54 @@
+#include "test_helper.hpp"
+
+template <typename T> struct test_norm {
+  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+    bool pass = true;
+
+    auto std_in = init_std_complex(init_re, init_im);
+    sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
+
+    T std_out{};
+    auto *cplx_out = sycl::malloc_shared<T>(1, Q);
+
+    // Get std::complex output
+    std_out = std::norm(std_in);
+
+    // Check cplx::complex output from device
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::norm<T>(cplx_input);
+     }).wait();
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+
+    // Check cplx::complex output from host
+    cplx_out[0] = sycl::ext::cplx::norm<T>(cplx_input);
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+
+    sycl::free(cplx_out, Q);
+
+    return pass;
+  }
+};
+
+// Difference between libstdc++ and libc++ when NaN's and Inf values are
+// combined.
+int main() {
+  sycl::queue Q;
+
+  bool test_passes = true;
+  test_passes &= test_valid_types<test_norm>(Q, 4.42, 2.02);
+
+  test_passes &= test_valid_types<test_norm>(Q, INFINITY, 2.02);
+  test_passes &= test_valid_types<test_norm>(Q, 4.42, INFINITY);
+  test_passes &= test_valid_types<test_norm>(Q, INFINITY, INFINITY);
+
+  test_passes &= test_valid_types<test_norm>(Q, NAN, 2.02);
+  test_passes &= test_valid_types<test_norm>(Q, 4.42, NAN);
+  test_passes &= test_valid_types<test_norm>(Q, NAN, NAN);
+
+  if (!test_passes)
+    std::cerr << "acos complex test fails\n";
+
+  return !test_passes;
+}

--- a/tests/polar_complex.cpp
+++ b/tests/polar_complex.cpp
@@ -1,0 +1,43 @@
+#include "test_helper.hpp"
+
+template <typename T> struct test_polar {
+  bool operator()(sycl::queue &Q, T init_rho, T init_theta) {
+    bool pass = true;
+
+    auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+    // Get std::complex output
+    std::complex<T> std_out = std::polar(init_rho, init_theta);
+
+    // Check cplx::complex output from device
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::polar<T>(init_rho, init_theta);
+     }).wait();
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+
+    // Check cplx::complex output from host
+    cplx_out[0] = sycl::ext::cplx::polar<T>(init_rho, init_theta);
+
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+
+    sycl::free(cplx_out, Q);
+
+    return pass;
+  }
+};
+
+// Note: Output is undefined if rho is negative or Nan, or theta is Inf
+int main() {
+  sycl::queue Q;
+
+  bool test_passes = true;
+  test_passes &= test_valid_types<test_polar>(Q, 4.42, 2.02);
+  test_passes &= test_valid_types<test_polar>(Q, 1, 3.14);
+  test_passes &= test_valid_types<test_polar>(Q, 1, -3.14);
+
+  if (!test_passes)
+    std::cerr << "acos complex test fails\n";
+
+  return !test_passes;
+}

--- a/tests/test_complex_types.cpp
+++ b/tests/test_complex_types.cpp
@@ -6,9 +6,7 @@ using namespace sycl::ext::cplx;
 #define TEST_MATH_OP_TYPE(op_name, op)                                         \
   template <typename T> struct test##_##op_name##_##types {                    \
     bool operator()() {                                                        \
-      static_assert(                                                           \
-          std::is_same_v<complex<T>, decltype(declval<complex<T>>() +          \
-                                              declval<complex<T>>())>);        \
+                                                                               \
       static_assert(                                                           \
           std::is_same_v<complex<T>,                                           \
                          decltype(declval<complex<T>>() op declval<T>())>);    \

--- a/tests/test_complex_types.cpp
+++ b/tests/test_complex_types.cpp
@@ -9,6 +9,13 @@ using namespace sycl::ext::cplx;
       static_assert(                                                           \
           std::is_same_v<complex<T>, decltype(declval<complex<T>>() +          \
                                               declval<complex<T>>())>);        \
+      static_assert(                                                           \
+          std::is_same_v<complex<T>,                                           \
+                         decltype(declval<complex<T>>() op declval<T>())>);    \
+                                                                               \
+      static_assert(                                                           \
+          std::is_same_v<complex<T>,                                           \
+                         decltype(declval<T>() op declval<complex<T>>())>);    \
       return true;                                                             \
     }                                                                          \
   };

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -140,3 +140,16 @@ bool check_results(sycl::ext::cplx::complex<T> output,
   }
   return true;
 }
+
+template <typename T>
+bool check_results(T output, T reference, bool is_device) {
+  if (!almost_equal_scalar(output, reference, SYCL_CPLX_TOL_ULP)) {
+    std::cerr << std::setprecision(std::numeric_limits<T>::max_digits10)
+              << "Test failed with complex_type: " << get_typename<T>()
+              << " Computed on " << (is_device ? "device" : "host")
+              << " Output: " << output << " Reference: " << reference
+              << std::endl;
+    return false;
+  }
+  return true;
+}

--- a/tests/test_operator_complex.cpp
+++ b/tests/test_operator_complex.cpp
@@ -132,7 +132,7 @@ int main() {
   sycl::queue Q;
 
   bool test_failed = false;
-  
+
   {
     bool test_passes = true;
     test_passes &= test_valid_types<test_add>(Q, 4.42, 2.02, -1.5, 3.2);
@@ -244,10 +244,9 @@ int main() {
     test_passes &= test_valid_types<test_add_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_add_assign>(Q, NAN, 2.02,
-    NAN, 2.02); test_passes &= test_valid_types<test_add_assign>(Q, 4.42,
-    NAN, 4.42, NAN); test_passes &= test_valid_types<test_add_assign>(Q, NAN,
-    NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_add_assign>(Q, NAN, 2.02, NAN, 2.02);
+    test_passes &= test_valid_types<test_add_assign>(Q, 4.42, NAN, 4.42, NAN);
+    test_passes &= test_valid_types<test_add_assign>(Q, NAN, NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_add_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -265,8 +264,7 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, 2.02,
-    -1.5, 3.2);
+    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, 2.02, -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_sub_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -275,10 +273,9 @@ int main() {
     test_passes &= test_valid_types<test_sub_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, 2.02,
-    NAN, 2.02); test_passes &= test_valid_types<test_sub_assign>(Q, 4.42,
-    NAN, 4.42, NAN); test_passes &= test_valid_types<test_sub_assign>(Q, NAN,
-    NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, 2.02, NAN, 2.02);
+    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, NAN, 4.42, NAN);
+    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_sub_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -296,8 +293,7 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, 2.02,
-    -1.5, 3.2);
+    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, 2.02, -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_mul_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -306,10 +302,9 @@ int main() {
     test_passes &= test_valid_types<test_mul_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, 2.02,
-    NAN, 2.02); test_passes &= test_valid_types<test_mul_assign>(Q, 4.42,
-    NAN, 4.42, NAN); test_passes &= test_valid_types<test_mul_assign>(Q, NAN,
-    NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, 2.02, NAN, 2.02);
+    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, NAN, 4.42, NAN);
+    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_mul_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -327,8 +322,7 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, 2.02,
-    -1.5, 3.2);
+    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, 2.02, -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_div_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -337,10 +331,9 @@ int main() {
     test_passes &= test_valid_types<test_div_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_div_assign>(Q, NAN, 2.02,
-    NAN, 2.02); test_passes &= test_valid_types<test_div_assign>(Q, 4.42,
-    NAN, 4.42, NAN); test_passes &= test_valid_types<test_div_assign>(Q, NAN,
-    NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_div_assign>(Q, NAN, 2.02, NAN, 2.02);
+    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, NAN, 4.42, NAN);
+    test_passes &= test_valid_types<test_div_assign>(Q, NAN, NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_div_assign>(Q, NAN, INFINITY, NAN, INFINITY);

--- a/tests/test_operator_complex.cpp
+++ b/tests/test_operator_complex.cpp
@@ -14,6 +14,7 @@
       std::complex<T> std_out{};                                               \
       auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q); \
                                                                                \
+      /* Check complex-complex op */                                           \
       std_out = std_in1 op std_in2;                                            \
                                                                                \
       Q.single_task([=]() {                                                    \
@@ -23,6 +24,30 @@
       pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
                                                                                \
       cplx_out[0] = cplx_input1 op cplx_input2;                                \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
+                                                                               \
+      /* Check complex-decimal op */                                           \
+      T dec = init_re2;                                                        \
+      std_out = std_in1 op init_deci(dec);                                     \
+                                                                               \
+      Q.single_task([=]() { cplx_out[0] = cplx_input1 op dec; }).wait();       \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
+                                                                               \
+      cplx_out[0] = cplx_input1 op dec;                                        \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
+                                                                               \
+      /* Check decimal-complex op */                                           \
+      dec = init_re1;                                                          \
+      std_out = init_deci(dec) op std_in2;                                     \
+                                                                               \
+      Q.single_task([=]() { cplx_out[0] = dec op cplx_input2; }).wait();       \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
+                                                                               \
+      cplx_out[0] = dec op cplx_input2;                                        \
                                                                                \
       pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
                                                                                \
@@ -64,6 +89,29 @@ test_op(test_div, /);
       cplx_inout[0].imag(init_im2);                                            \
                                                                                \
       cplx_inout[0] op_assign cplx_input;                                      \
+                                                                               \
+      pass &= check_results(                                                   \
+          cplx_inout[0], std::complex<T>(std_inout.real(), std_inout.imag()),  \
+          /*is_device*/ false);                                                \
+                                                                               \
+      /* Check complex-decimal op */                                           \
+      std_inout = init_std_complex(init_re2, init_im2);                        \
+      cplx_inout[0].real(init_re2);                                            \
+      cplx_inout[0].imag(init_im2);                                            \
+                                                                               \
+      T dec = init_re1;                                                        \
+      std_inout op_assign init_deci(dec);                                      \
+                                                                               \
+      Q.single_task([=]() { cplx_inout[0] op_assign dec; }).wait();            \
+                                                                               \
+      pass &= check_results(                                                   \
+          cplx_inout[0], std::complex<T>(std_inout.real(), std_inout.imag()),  \
+          /*is_device*/ true);                                                 \
+                                                                               \
+      cplx_inout[0].real(init_re2);                                            \
+      cplx_inout[0].imag(init_im2);                                            \
+                                                                               \
+      cplx_inout[0] op_assign dec;                                             \
                                                                                \
       pass &= check_results(                                                   \
           cplx_inout[0], std::complex<T>(std_inout.real(), std_inout.imag()),  \
@@ -196,9 +244,10 @@ int main() {
     test_passes &= test_valid_types<test_add_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_add_assign>(Q, NAN, 2.02, NAN, 2.02);
-    test_passes &= test_valid_types<test_add_assign>(Q, 4.42, NAN, 4.42, NAN);
-    test_passes &= test_valid_types<test_add_assign>(Q, NAN, NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_add_assign>(Q, NAN, 2.02,
+    NAN, 2.02); test_passes &= test_valid_types<test_add_assign>(Q, 4.42,
+    NAN, 4.42, NAN); test_passes &= test_valid_types<test_add_assign>(Q, NAN,
+    NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_add_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -216,7 +265,8 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, 2.02, -1.5, 3.2);
+    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, 2.02,
+    -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_sub_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -225,9 +275,10 @@ int main() {
     test_passes &= test_valid_types<test_sub_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, 2.02, NAN, 2.02);
-    test_passes &= test_valid_types<test_sub_assign>(Q, 4.42, NAN, 4.42, NAN);
-    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_sub_assign>(Q, NAN, 2.02,
+    NAN, 2.02); test_passes &= test_valid_types<test_sub_assign>(Q, 4.42,
+    NAN, 4.42, NAN); test_passes &= test_valid_types<test_sub_assign>(Q, NAN,
+    NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_sub_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -245,7 +296,8 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, 2.02, -1.5, 3.2);
+    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, 2.02,
+    -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_mul_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -254,9 +306,10 @@ int main() {
     test_passes &= test_valid_types<test_mul_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, 2.02, NAN, 2.02);
-    test_passes &= test_valid_types<test_mul_assign>(Q, 4.42, NAN, 4.42, NAN);
-    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_mul_assign>(Q, NAN, 2.02,
+    NAN, 2.02); test_passes &= test_valid_types<test_mul_assign>(Q, 4.42,
+    NAN, 4.42, NAN); test_passes &= test_valid_types<test_mul_assign>(Q, NAN,
+    NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_mul_assign>(Q, NAN, INFINITY, NAN, INFINITY);
@@ -274,7 +327,8 @@ int main() {
 
   {
     bool test_passes = true;
-    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, 2.02, -1.5, 3.2);
+    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, 2.02,
+    -1.5, 3.2);
 
     test_passes &=
         test_valid_types<test_div_assign>(Q, INFINITY, 2.02, INFINITY, 2.02);
@@ -283,9 +337,10 @@ int main() {
     test_passes &= test_valid_types<test_div_assign>(Q, INFINITY, INFINITY,
                                                      INFINITY, INFINITY);
 
-    test_passes &= test_valid_types<test_div_assign>(Q, NAN, 2.02, NAN, 2.02);
-    test_passes &= test_valid_types<test_div_assign>(Q, 4.42, NAN, 4.42, NAN);
-    test_passes &= test_valid_types<test_div_assign>(Q, NAN, NAN, NAN, NAN);
+    test_passes &= test_valid_types<test_div_assign>(Q, NAN, 2.02,
+    NAN, 2.02); test_passes &= test_valid_types<test_div_assign>(Q, 4.42,
+    NAN, 4.42, NAN); test_passes &= test_valid_types<test_div_assign>(Q, NAN,
+    NAN, NAN, NAN);
 
     test_passes &=
         test_valid_types<test_div_assign>(Q, NAN, INFINITY, NAN, INFINITY);


### PR DESCRIPTION
This PR adds additional testing for some math functions, and operator overloads.

* Adds testing for abs, arg, norm, and polar
* Adds testing for complex-scalar operators