### PR TITLE
Change method for testing arc math

### DIFF
--- a/tests/acos_complex.cpp
+++ b/tests/acos_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_acos {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::acos(std_in);
+    if (is_error_checking)
+      std_out = std::acos(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::acos<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::acos<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::cos<T>(sycl::ext::cplx::acos<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::acos<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::acos<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::cos<T>(sycl::ext::cplx::acos<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_acos>(Q, 4.42, 2.02);
 
-  test_passes &= test_valid_types<test_acos>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_acos>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_acos>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_acos>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_acos>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_acos>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_acos>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_acos>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_acos>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_acos>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_acos>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_acos>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_acos>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_acos>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_acos>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_acos>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_acos>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_acos>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_acos>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_acos>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "acos complex test fails\n";

--- a/tests/acos_complex.cpp
+++ b/tests/acos_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_acos {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_acos {
       cplx_out[0] =
           sycl::ext::cplx::cos<T>(sycl::ext::cplx::acos<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 

--- a/tests/acosh_complex.cpp
+++ b/tests/acosh_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_acosh {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::acosh(std_in);
+    if (is_error_checking)
+      std_out = std::acosh(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::acosh<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::acosh<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::cosh<T>(sycl::ext::cplx::acosh<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::acosh<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::acosh<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::cosh<T>(sycl::ext::cplx::acosh<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_acosh>(Q, 4.42, 2.02);
 
-  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_acosh>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_acosh>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_acosh>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_acosh>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_acosh>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_acosh>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_acosh>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_acosh>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_acosh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_acosh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_acosh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_acosh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_acosh>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "acosh complex test fails\n";

--- a/tests/acosh_complex.cpp
+++ b/tests/acosh_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_acosh {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_acosh {
       cplx_out[0] =
           sycl::ext::cplx::cosh<T>(sycl::ext::cplx::acosh<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 

--- a/tests/asin_complex.cpp
+++ b/tests/asin_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_asin {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_asin {
       cplx_out[0] =
           sycl::ext::cplx::sin<T>(sycl::ext::cplx::asin<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 

--- a/tests/asin_complex.cpp
+++ b/tests/asin_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_asin {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::asin(std_in);
+    if (is_error_checking)
+      std_out = std::asin(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::asin<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::asin<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::sin<T>(sycl::ext::cplx::asin<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::asin<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::asin<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::sin<T>(sycl::ext::cplx::asin<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_asin>(Q, 0.42, 2.02);
 
-  test_passes &= test_valid_types<test_asin>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_asin>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_asin>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_asin>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_asin>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_asin>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_asin>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_asin>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_asin>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_asin>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_asin>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_asin>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_asin>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_asin>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_asin>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_asin>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_asin>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_asin>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_asin>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_asin>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "asin complex test fails\n";

--- a/tests/asinh_complex.cpp
+++ b/tests/asinh_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_asinh {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_asinh {
       cplx_out[0] =
           sycl::ext::cplx::sinh<T>(sycl::ext::cplx::asinh<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 

--- a/tests/asinh_complex.cpp
+++ b/tests/asinh_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_asinh {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::asinh(std_in);
+    if (is_error_checking)
+      std_out = std::asinh(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::asinh<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::asinh<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::sinh<T>(sycl::ext::cplx::asinh<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::asinh<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::asinh<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::sinh<T>(sycl::ext::cplx::asinh<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_asinh>(Q, 0.42, 2.02);
 
-  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_asinh>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_asinh>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_asinh>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_asinh>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_asinh>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_asinh>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_asinh>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_asinh>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_asinh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_asinh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_asinh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_asinh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_asinh>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "asinh complex test fails\n";

--- a/tests/atan_complex.cpp
+++ b/tests/atan_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_atan {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_atan {
       cplx_out[0] =
           sycl::ext::cplx::tan<T>(sycl::ext::cplx::atan<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 

--- a/tests/atan_complex.cpp
+++ b/tests/atan_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_atan {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::atan(std_in);
+    if (is_error_checking)
+      std_out = std::atan(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::atan<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::atan<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::tan<T>(sycl::ext::cplx::atan<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::atan<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::atan<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::tan<T>(sycl::ext::cplx::atan<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_atan>(Q, 0.42, 2.02);
 
-  test_passes &= test_valid_types<test_atan>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_atan>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_atan>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_atan>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_atan>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_atan>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_atan>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_atan>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_atan>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_atan>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_atan>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_atan>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_atan>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_atan>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_atan>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_atan>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_atan>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_atan>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_atan>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_atan>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "atan complex test fails\n";

--- a/tests/atanh_complex.cpp
+++ b/tests/atanh_complex.cpp
@@ -1,27 +1,40 @@
 #include "test_helper.hpp"
 
 template <typename T> struct test_atanh {
-  bool operator()(sycl::queue &Q, T init_re, T init_im) {
+  bool operator()(sycl::queue &Q, T init_re, T init_im,
+                  bool is_error_checking = false) {
     bool pass = true;
 
     auto std_in = init_std_complex(init_re, init_im);
     sycl::ext::cplx::complex<T> cplx_input{init_re, init_im};
 
-    std::complex<T> std_out{};
+    std::complex<T> std_out{init_re, init_im};
     auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
 
     // Get std::complex output
-    std_out = std::atanh(std_in);
+    if (is_error_checking)
+      std_out = std::atanh(std_in);
 
     // Check cplx::complex output from device
-    Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::atanh<T>(cplx_input);
-     }).wait();
+    if (is_error_checking) {
+      Q.single_task(
+          [=]() { cplx_out[0] = sycl::ext::cplx::atanh<T>(cplx_input); });
+    } else {
+      Q.single_task([=]() {
+        cplx_out[0] =
+            sycl::ext::cplx::tanh<T>(sycl::ext::cplx::atanh<T>(cplx_input));
+      });
+    }
+    Q.wait();
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
 
     // Check cplx::complex output from host
-    cplx_out[0] = sycl::ext::cplx::atanh<T>(cplx_input);
+    if (is_error_checking)
+      cplx_out[0] = sycl::ext::cplx::atanh<T>(cplx_input);
+    else
+      cplx_out[0] =
+          sycl::ext::cplx::tanh<T>(sycl::ext::cplx::atanh<T>(cplx_input));
 
     pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
 
@@ -37,18 +50,18 @@ int main() {
   bool test_passes = true;
   test_passes &= test_valid_types<test_atanh>(Q, 0.42, 2.02);
 
-  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, 2.02);
-  test_passes &= test_valid_types<test_atanh>(Q, 4.42, INFINITY);
-  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, INFINITY);
+  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, 2.02, true);
+  test_passes &= test_valid_types<test_atanh>(Q, 4.42, INFINITY, true);
+  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, INFINITY, true);
 
-  test_passes &= test_valid_types<test_atanh>(Q, NAN, 2.02);
-  test_passes &= test_valid_types<test_atanh>(Q, 4.42, NAN);
-  test_passes &= test_valid_types<test_atanh>(Q, NAN, NAN);
+  test_passes &= test_valid_types<test_atanh>(Q, NAN, 2.02, true);
+  test_passes &= test_valid_types<test_atanh>(Q, 4.42, NAN, true);
+  test_passes &= test_valid_types<test_atanh>(Q, NAN, NAN, true);
 
-  test_passes &= test_valid_types<test_atanh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, NAN);
-  test_passes &= test_valid_types<test_atanh>(Q, NAN, INFINITY);
-  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, NAN);
+  test_passes &= test_valid_types<test_atanh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, NAN, true);
+  test_passes &= test_valid_types<test_atanh>(Q, NAN, INFINITY, true);
+  test_passes &= test_valid_types<test_atanh>(Q, INFINITY, NAN, true);
 
   if (!test_passes)
     std::cerr << "atanh complex test fails\n";

--- a/tests/atanh_complex.cpp
+++ b/tests/atanh_complex.cpp
@@ -27,7 +27,8 @@ template <typename T> struct test_atanh {
     }
     Q.wait();
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true,
+                          /*tol_multiplier*/ 2);
 
     // Check cplx::complex output from host
     if (is_error_checking)
@@ -36,7 +37,8 @@ template <typename T> struct test_atanh {
       cplx_out[0] =
           sycl::ext::cplx::tanh<T>(sycl::ext::cplx::atanh<T>(cplx_input));
 
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false,
+                          /*tol_multiplier*/ 2);
 
     sycl::free(cplx_out, Q);
 


### PR DESCRIPTION
This PR adjusts the method for testing arc math operations. This relates to issues of the C++ standard not having a strict standard for multi valued operations. 

The arc math tests now check if the operation is an inverting operator. Ex: `acos(cos(x)) == x`. This method has some issues such related to handling tolerances to accommodate this the ULP has been increased from 5 to 10. Error code checking is still performed in the previous way.

Additionally, this PR also changes how the error within operations are being checked. Previously the difference between each real and imaginary component would be checked separately. This is generally fine but in some circumstances where the total complex number's magnitude is large but one of the components is small then a small amount of total error can cause the test to fail.
The test helper is now changed so it tests the magnitude of (reference - output).

Related issue: https://github.com/argonne-lcf/SyclCPLX/issues/7