### PR TITLE
Update dpcpp macro from __INTEL_LLVM_COMPILER to __SYCL_COMPILER_VERSION

### DIFF
--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -72,7 +72,9 @@ bool test_valid_types(argsT... args) {
 
 // Helpers for comparison
 
-// Do not define for DPCPP as it already defines this struct
+// Do not define for public `intel/llvm` and oneAPI
+// oneAPI define `__INTEL_LLVM_COMPILER` but `intel/llvm` doesn't.
+// So we use the intel-implementation-only macro `__SYCL_COMPILER_VERSION` as an ID
 #ifndef __SYCL_COMPILER_VERSION
 namespace std {
 

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -73,7 +73,7 @@ bool test_valid_types(argsT... args) {
 // Helpers for comparison
 
 // Do not define for DPCPP as it already defines this struct
-#ifndef __INTEL_LLVM_COMPILER
+#ifndef __SYCL_COMPILER_VERSION
 namespace std {
 
 // Specialization of std::numeric<sycl::half> for almost_equal


### PR DESCRIPTION
This PR propose to updates the ```test_helper.hpp``` file to use ```__SYCL_COMPILER_VERSION``` instead of ```__INTEL_LLVM_COMPILER```

The reason for this change is that ```__INTEL_LLVM_COMPILER``` is set when you *"you have installed both Intel® oneAPI Base Toolkit (BaseKit) and Intel® oneAPI HPC toolkit (HPC Kit)"* and have the dpcpp, icx .. compilers.
In the case where you build this repo using a local build of intel/llvm/clang++, the ```__INTEL_LLVM_COMPILER```  macro will not be set and will result in a compile-time error since the ```numeric_limits``` is redefined.

```__SYCL_COMPILER_VERSION``` is set by DPC++ and is not part of the SYCL spec.
There is no conflict with other sycl implementations, and the logic of that condition is still the same.

Source for reference:
 - [https://www.intel.com](https://www.intel.com/content/www/us/en/developer/articles/technical/use-predefined-macros-for-specific-code-for-intel-dpcpp-compiler-intel-cpp-compiler-intel-cpp-compiler-classic.html)
 - [https://github.com](https://github.com/intel/llvm/issues/1894)