### PR TITLE
Pr/custom namespace

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -244,7 +244,15 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 // clang-format on
 
-#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace sycl::ext::cplx {
+#ifndef _SYCL_CPLX_NAMESPACE
+#ifdef __HIPSYCL__
+#define _SYCL_CPLX_NAMESPACE hipsycl::sycl::ext::cplx
+#else
+#define _SYCL_CPLX_NAMESPACE sycl::ext::cplx
+#endif
+#endif
+
+#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace _SYCL_CPLX_NAMESPACE {
 #define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
 #define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
   inline __attribute__((__visibility__("hidden"), __always_inline__))

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -982,13 +982,12 @@ template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
 // real
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-real(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp real(const complex<_Tp> &__c) {
   return __c.real();
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     real(_Tp __re) {
   return __re;
@@ -997,13 +996,12 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 // imag
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-imag(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp imag(const complex<_Tp> &__c) {
   return __c.imag();
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     imag(_Tp) {
   return 0;
@@ -1012,21 +1010,19 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 // abs
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-abs(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp abs(const complex<_Tp> &__c) {
   return sycl::hypot(__c.real(), __c.imag());
 }
 
 // arg
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-arg(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp arg(const complex<_Tp> &__c) {
   return sycl::atan2(__c.imag(), __c.real());
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<std::is_integral<_Tp>::value ||
                                 std::is_same<_Tp, double>::value,
                             double>::type
@@ -1035,7 +1031,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<std::is_same<_Tp, float>::value, float>::type
     arg(_Tp __re) {
   return sycl::atan2(0.F, __re);
@@ -1044,8 +1040,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // norm
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-norm(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp norm(const complex<_Tp> &__c) {
   if (sycl::isinf(__c.real()))
     return sycl::fabs(__c.real());
   if (sycl::isinf(__c.imag()))
@@ -1054,7 +1049,7 @@ norm(const complex<_Tp> &__c) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     norm(_Tp __re) {
   typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
@@ -1064,13 +1059,12 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // conj
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-conj(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> conj(const complex<_Tp> &__c) {
   return complex<_Tp>(__c.real(), -__c.imag());
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
     conj(_Tp __re) {
   typedef
@@ -1081,8 +1075,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // proj
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-proj(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
     __r = complex<_Tp>(INFINITY, sycl::copysign(_Tp(0), __c.imag()));
@@ -1090,7 +1083,7 @@ proj(const complex<_Tp> &__c) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
     std::is_floating_point<_Tp>::value,
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
 proj(_Tp __re) {
@@ -1100,7 +1093,7 @@ proj(_Tp __re) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
     std::is_integral<_Tp>::value,
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
 proj(_Tp __re) {
@@ -1112,7 +1105,7 @@ proj(_Tp __re) {
 // polar
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
+complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   if (sycl::isnan(__theta)) {
@@ -1137,23 +1130,21 @@ SYCL_EXTERNAL complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
 // log
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> log(const complex<_Tp> &__x) {
   return complex<_Tp>(sycl::log(abs(__x)), arg(__x));
 }
 
 // log10
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log10(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> log10(const complex<_Tp> &__x) {
   return log(__x) / sycl::log(_Tp(10));
 }
 
 // sqrt
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> sqrt(const complex<_Tp> &__x) {
+complex<_Tp> sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
   if (sycl::isinf(__x.real())) {
@@ -1170,7 +1161,7 @@ SYCL_EXTERNAL complex<_Tp> sqrt(const complex<_Tp> &__x) {
 // exp
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> exp(const complex<_Tp> &__x) {
+complex<_Tp> exp(const complex<_Tp> &__x) {
   _Tp __i = __x.imag();
   if (__i == 0) {
     return complex<_Tp>(sycl::exp(__x.real()),
@@ -1193,23 +1184,22 @@ SYCL_EXTERNAL complex<_Tp> exp(const complex<_Tp> &__x) {
 // pow
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp> &__x,
+                                                  const complex<_Tp> &__y) {
   return exp(__y * log(__x));
 }
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL
-    _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
-    pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
+pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
   return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
@@ -1219,7 +1209,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
@@ -1238,7 +1228,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
 // asinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
+complex<_Tp> asinh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1266,7 +1256,7 @@ SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
 // acosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
+complex<_Tp> acosh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1299,7 +1289,7 @@ SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
 // atanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
+complex<_Tp> atanh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.imag())) {
     return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
@@ -1329,7 +1319,7 @@ SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
 // sinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> sinh(const complex<_Tp> &__x) {
+complex<_Tp> sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(__x.real(), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1343,7 +1333,7 @@ SYCL_EXTERNAL complex<_Tp> sinh(const complex<_Tp> &__x) {
 // cosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> cosh(const complex<_Tp> &__x) {
+complex<_Tp> cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1359,7 +1349,7 @@ SYCL_EXTERNAL complex<_Tp> cosh(const complex<_Tp> &__x) {
 // tanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> tanh(const complex<_Tp> &__x) {
+complex<_Tp> tanh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real())) {
     if (!sycl::isfinite(__x.imag()))
       return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()), _Tp(0));
@@ -1381,7 +1371,7 @@ SYCL_EXTERNAL complex<_Tp> tanh(const complex<_Tp> &__x) {
 // asin
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
+complex<_Tp> asin(const complex<_Tp> &__x) {
   complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1389,7 +1379,7 @@ SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
 // acos
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
+complex<_Tp> acos(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1423,8 +1413,7 @@ SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
 // atan
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-atan(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> atan(const complex<_Tp> &__x) {
   complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1432,8 +1421,7 @@ atan(const complex<_Tp> &__x) {
 // sin
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-sin(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> sin(const complex<_Tp> &__x) {
   complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1441,16 +1429,14 @@ sin(const complex<_Tp> &__x) {
 // cos
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-cos(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> cos(const complex<_Tp> &__x) {
   return cosh(complex<_Tp>(-__x.imag(), __x.real()));
 }
 
 // tan
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-tan(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> tan(const complex<_Tp> &__x) {
   complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1513,7 +1499,7 @@ operator<<(std::basic_ostream<_CharT, _Traits> &__os, const complex<_Tp> &__x) {
 }
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
+_SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
 operator<<(const sycl::stream &__ss, const complex<_Tp> &_x) {
   return __ss << "(" << _x.real() << "," << _x.imag() << ")";
 }

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -1209,7 +1209,7 @@ template <class _Tp, class _Up,
 _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
 pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
@@ -1219,7 +1219,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
@@ -1229,7 +1229,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 // __sqr, computes pow(x, 2)

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -255,11 +255,18 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace _SYCL_CPLX_NAMESPACE {
 #define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
 #define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
-  inline __attribute__((__visibility__("hidden"), __always_inline__))
+  [[gnu::always_inline]] [[clang::always_inline]] inline
 
 #include <complex>
 #include <sstream> // for std::basic_ostringstream
+#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
+#elif __has_include(<CL/sycl.hpp>)
+// support oneAPI 2022.X and earlier
+#include <CL/sycl.hpp>
+#else
+#error "SYCL header not found"
+#endif
 #include <type_traits>
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD


### PR DESCRIPTION
- allow custom namespace by setting _SYCL_CPLX_NAMESPACE before including the header
- default to using hipSYCL namespace when detected (::sycl is an alias so this is necessary for the namespaces to work)
- support older oneAPI with CL/sycl.hpp header
- remove SYCL_EXTERNAL macro, not needed for header only and poses portability issues since it's optional in the spec
- use more portable always inline attributes

In addition to making a step towards supporting hipSYCL, this will also simplify the use of SyclCPLX in gtensor without modifying the headers, as it needs a custom namespace to avoid namespace related compile issues on certain oneAPI version.