### PR TITLE
Update complex implementation and tests

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -271,6 +271,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
 
+namespace detail {
 template <class _Tp> struct __numeric_type {
   static void __test(...);
   static sycl::half __test(sycl::half);
@@ -328,6 +329,7 @@ public:
 
 template <class _A1, class _A2 = void, class _A3 = void>
 class __promote : public __promote_imp<_A1, _A2, _A3> {};
+}
 
 template <class _Tp, class _Enable = void> class complex;
 
@@ -386,13 +388,6 @@ public:
     __im_ = value_type();
     return *this;
   }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
   &operator+=(complex<value_type> &__c, value_type __re) {
     __c.__re_ += __re;
@@ -416,6 +411,12 @@ public:
     return __c;
   }
 
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
   template <class _Xp>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
   &operator+=(complex<value_type> &__x, const complex<_Xp> &__y) {
@@ -450,13 +451,13 @@ public:
     return __t;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(const complex<value_type> &__x, const value_type &__y) {
+  operator+(const complex<value_type> &__x, value_type __y) {
     complex<value_type> __t(__x);
     __t += __y;
     return __t;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(const value_type &__x, const complex<value_type> &__y) {
+  operator+(value_type __x, const complex<value_type> &__y) {
     complex<value_type> __t(__y);
     __t += __x;
     return __t;
@@ -473,13 +474,13 @@ public:
     return __t;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(const complex<value_type> &__x, const value_type &__y) {
+  operator-(const complex<value_type> &__x, value_type __y) {
     complex<value_type> __t(__x);
     __t -= __y;
     return __t;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(const value_type &__x, const complex<value_type> &__y) {
+  operator-(value_type __x, const complex<value_type> &__y) {
     complex<value_type> __t(-__y);
     __t += __x;
     return __t;
@@ -541,13 +542,13 @@ public:
     return complex<value_type>(__x, __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator*(const complex<value_type> &__x, const value_type &__y) {
+  operator*(const complex<value_type> &__x, value_type __y) {
     complex<value_type> __t(__x);
     __t *= __y;
     return __t;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator*(const value_type &__x, const complex<value_type> &__y) {
+  operator*(value_type __x, const complex<value_type> &__y) {
     complex<value_type> __t(__y);
     __t *= __x;
     return __t;
@@ -590,11 +591,11 @@ public:
     return complex<value_type>(__x, __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator/(const complex<value_type> &__x, const value_type &__y) {
+  operator/(const complex<value_type> &__x, value_type __y) {
     return complex<value_type>(__x.real() / __y, __x.imag() / __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator/(const value_type &__x, const complex<value_type> &__y) {
+  operator/(value_type __x, const complex<value_type> &__y) {
     complex<value_type> __t(__x);
     __t /= __y;
     return __t;
@@ -605,11 +606,11 @@ public:
     return __x.real() == __y.real() && __x.imag() == __y.imag();
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator==(const complex<value_type> &__x, const value_type &__y) {
+  operator==(const complex<value_type> &__x, value_type __y) {
     return __x.real() == __y && __x.imag() == 0;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator==(const value_type &__x, const complex<value_type> &__y) {
+  operator==(value_type __x, const complex<value_type> &__y) {
     return __x == __y.real() && 0 == __y.imag();
   }
 
@@ -618,11 +619,11 @@ public:
     return !(__x == __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator!=(const complex<value_type> &__x, const value_type &__y) {
+  operator!=(const complex<value_type> &__x, value_type __y) {
     return !(__x == __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator!=(const value_type &__x, const complex<value_type> &__y) {
+  operator!=(value_type __x, const complex<value_type> &__y) {
     return !(__x == __y);
   }
 
@@ -689,6 +690,7 @@ public:
   }
 };
 
+namespace detail {
 template <class _Tp, bool = std::is_integral<_Tp>::value,
           bool = is_genfloat<_Tp>::value>
 struct __libcpp_complex_overload_traits {};
@@ -704,59 +706,60 @@ template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
   typedef _Tp _ValueType;
   typedef complex<_Tp> _ComplexType;
 };
+}
 
 // real
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp real(const complex<_Tp> &__c) {
   return __c.real();
 }
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     real(_Tp __re) {
   return __re;
 }
 
 // imag
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp imag(const complex<_Tp> &__c) {
   return __c.imag();
 }
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     imag(_Tp) {
   return 0;
 }
 
 // abs
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp abs(const complex<_Tp> &__c) {
   return sycl::hypot(__c.real(), __c.imag());
 }
 
 // arg
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp arg(const complex<_Tp> &__c) {
   return sycl::atan2(__c.imag(), __c.real());
 }
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-typename __libcpp_complex_overload_traits<_Tp>::_ValueType arg(_Tp __re) {
-  typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType arg(_Tp __re) {
+  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
   return sycl::atan2<_ValueType>(0, __re);
 }
 
 // norm
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp norm(const complex<_Tp> &__c) {
   if (sycl::isinf(__c.real()))
     return sycl::fabs(__c.real());
@@ -767,31 +770,31 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp norm(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     norm(_Tp __re) {
-  typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
   return static_cast<_ValueType>(__re) * __re;
 }
 
 // conj
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> conj(const complex<_Tp> &__c) {
   return complex<_Tp>(__c.real(), -__c.imag());
 }
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
+    typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
     conj(_Tp __re) {
   typedef
-      typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+      typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
   return _ComplexType(__re);
 }
 
 // proj
 
-template <class _Tp>
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
@@ -801,9 +804,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
+  typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
   proj(_Tp __re) {
-  typedef typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
 
   if constexpr(!std::is_integral_v<_Tp>) {
     if (sycl::isinf(__re))
@@ -902,9 +905,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp> &__x,
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename detail::__promote<_Tp, _Up>::type>
 pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
-  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
@@ -912,9 +915,9 @@ template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
-                            complex<typename __promote<_Tp, _Up>::type>>::type
+                            complex<typename detail::__promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
-  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
@@ -922,9 +925,9 @@ template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
-                            complex<typename __promote<_Tp, _Up>::type>>::type
+                            complex<typename detail::__promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
-  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -487,15 +487,15 @@ public:
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator-(const complex<value_type> &__x) {
-    return complex<value_type>(-__x.real(), -__x.imag());
+    return complex<value_type>(-__x.__re_, -__x.__im_);
   }
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator*(const complex<value_type> &__z, const complex<value_type> &__w) {
-    value_type __a = __z.real();
-    value_type __b = __z.imag();
-    value_type __c = __w.real();
-    value_type __d = __w.imag();
+    value_type __a = __z.__re_;
+    value_type __b = __z.__im_;
+    value_type __c = __w.__re_;
+    value_type __d = __w.__im_;
     value_type __ac = __a * __c;
     value_type __bd = __b * __d;
     value_type __ad = __a * __d;
@@ -557,10 +557,10 @@ public:
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator/(const complex<value_type> &__z, const complex<value_type> &__w) {
     int __ilogbw = 0;
-    value_type __a = __z.real();
-    value_type __b = __z.imag();
-    value_type __c = __w.real();
-    value_type __d = __w.imag();
+    value_type __a = __z.__re_;
+    value_type __b = __z.__im_;
+    value_type __c = __w.__re_;
+    value_type __d = __w.__im_;
     value_type __logbw = sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
     if (sycl::isfinite(__logbw)) {
       __ilogbw = static_cast<int>(__logbw);
@@ -592,7 +592,7 @@ public:
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator/(const complex<value_type> &__x, value_type __y) {
-    return complex<value_type>(__x.real() / __y, __x.imag() / __y);
+    return complex<value_type>(__x.__re_ / __y, __x.__im_ / __y);
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator/(value_type __x, const complex<value_type> &__y) {
@@ -603,15 +603,15 @@ public:
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
   operator==(const complex<value_type> &__x, const complex<value_type> &__y) {
-    return __x.real() == __y.real() && __x.imag() == __y.imag();
+    return __x.__re_ == __y.__re_ && __x.__im_ == __y.__im_;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
   operator==(const complex<value_type> &__x, value_type __y) {
-    return __x.real() == __y && __x.imag() == 0;
+    return __x.__re_ == __y && __x.__im_ == 0;
   }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
   operator==(value_type __x, const complex<value_type> &__y) {
-    return __x == __y.real() && 0 == __y.imag();
+    return __x == __y.__re_ && 0 == __y.__im_;
   }
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
@@ -680,13 +680,13 @@ public:
     __s.flags(__os.flags());
     __s.imbue(__os.getloc());
     __s.precision(__os.precision());
-    __s << '(' << __x.real() << ',' << __x.imag() << ')';
+    __s << '(' << __x.__re_ << ',' << __x.__im_ << ')';
     return __os << __s.str();
   }
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend const sycl::stream
   &operator<<(const sycl::stream &__ss, const complex<value_type> &_x) {
-    return __ss << "(" << _x.real() << "," << _x.imag() << ")";
+    return __ss << "(" << _x.__re_ << "," << _x.__im_ << ")";
   }
 };
 

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -329,7 +329,7 @@ public:
 template <class _A1, class _A2 = void, class _A3 = void>
 class __promote : public __promote_imp<_A1, _A2, _A3> {};
 
-template <class _Tp> class complex;
+template <class _Tp, class _Enable = void> class complex;
 
 template <class _Tp>
 struct is_gencomplex
@@ -345,11 +345,7 @@ struct is_genfloat
                                        std::is_same_v<_Tp, sycl::half>> {};
 
 template <class _Tp>
-complex<_Tp> operator*(const complex<_Tp> &__z, const complex<_Tp> &__w);
-template <class _Tp>
-complex<_Tp> operator/(const complex<_Tp> &__x, const complex<_Tp> &__y);
-
-template <class _Tp> class complex {
+class complex<_Tp, typename std::enable_if<is_genfloat<_Tp>::value>::type> {
 public:
   typedef _Tp value_type;
 
@@ -358,21 +354,21 @@ private:
   value_type __im_;
 
 public:
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      const value_type &__re = value_type(),
-      const value_type &__im = value_type())
-      : __re_(__re), __im_(__im) {}
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(value_type __re = value_type(), value_type __im = value_type()) : __re_(__re), __im_(__im) {
 
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      const std::complex<_Xp> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY operator std::complex<_Xp>() {
-    return std::complex<_Xp>(__re_, __im_);
+  }
+
+  template <typename _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c) : __re_(__c.real()), __im_(__c.imag()) {
+
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const std::complex<value_type> &__c) : __re_(__c.real()), __im_(__c.imag()) {
+
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr operator std::complex<value_type>() const {
+    return std::complex<value_type>(__re_, __im_);
   }
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type real() const {
@@ -385,601 +381,316 @@ public:
   _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
   _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
 
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const value_type &__re) {
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(value_type __re) {
     __re_ = __re;
     __im_ = value_type();
     return *this;
   }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(const value_type &__re) {
-    __re_ += __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(const value_type &__re) {
-    __re_ -= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(const value_type &__re) {
-    __re_ *= __re;
-    __im_ *= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(const value_type &__re) {
-    __re_ /= __re;
-    __im_ /= __re;
-    return *this;
-  }
-
   template <class _Xp>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
     __re_ = __c.real();
     __im_ = __c.imag();
     return *this;
   }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator+=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ += __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator-=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ -= __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator*=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ *= __re;
+    __c.__im_ *= __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator/=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ /= __re;
+    __c.__im_ /= __re;
+    return __c;
+  }
+
   template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator=(const std::complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator+=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x.__re_ += __y.real();
+    __x.__im_ += __y.imag();
+    return __x;
   }
   template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator+=(const complex<_Xp> &__c) {
-    __re_ += __c.real();
-    __im_ += __c.imag();
-    return *this;
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator-=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x.__re_ -= __y.real();
+    __x.__im_ -= __y.imag();
+    return __x;
   }
   template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator-=(const complex<_Xp> &__c) {
-    __re_ -= __c.real();
-    __im_ -= __c.imag();
-    return *this;
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator*=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x = __x * complex(__y.real(), __y.imag());
+    return __x;
   }
   template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator*=(const complex<_Xp> &__c) {
-    *this = *this * complex(__c.real(), __c.imag());
-    return *this;
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex
+  &operator/=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x = __x / complex(__y.real(), __y.imag());
+    return __x;
   }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator/=(const complex<_Xp> &__c) {
-    *this = *this / complex(__c.real(), __c.imag());
-    return *this;
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t += __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x, const value_type &__y) {
+    complex<value_type> __t(__x);
+    __t += __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const value_type &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__y);
+    __t += __x;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x) {
+    return __x;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t -= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x, const value_type &__y) {
+    complex<value_type> __t(__x);
+    __t -= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const value_type &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(-__y);
+    __t += __x;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x) {
+    return complex<value_type>(-__x.real(), -__x.imag());
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(const complex<value_type> &__z, const complex<value_type> &__w) {
+    value_type __a = __z.real();
+    value_type __b = __z.imag();
+    value_type __c = __w.real();
+    value_type __d = __w.imag();
+    value_type __ac = __a * __c;
+    value_type __bd = __b * __d;
+    value_type __ad = __a * __d;
+    value_type __bc = __b * __c;
+    value_type __x = __ac - __bd;
+    value_type __y = __ad + __bc;
+    if (sycl::isnan(__x) && sycl::isnan(__y)) {
+      bool __recalc = false;
+      if (sycl::isinf(__a) || sycl::isinf(__b)) {
+        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0), __a);
+        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0), __b);
+        if (sycl::isnan(__c))
+          __c = sycl::copysign(value_type(0), __c);
+        if (sycl::isnan(__d))
+          __d = sycl::copysign(value_type(0), __d);
+        __recalc = true;
+      }
+      if (sycl::isinf(__c) || sycl::isinf(__d)) {
+        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0), __c);
+        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0), __d);
+        if (sycl::isnan(__a))
+          __a = sycl::copysign(value_type(0), __a);
+        if (sycl::isnan(__b))
+          __b = sycl::copysign(value_type(0), __b);
+        __recalc = true;
+      }
+      if (!__recalc && (sycl::isinf(__ac) || sycl::isinf(__bd) ||
+                        sycl::isinf(__ad) || sycl::isinf(__bc))) {
+        if (sycl::isnan(__a))
+          __a = sycl::copysign(value_type(0), __a);
+        if (sycl::isnan(__b))
+          __b = sycl::copysign(value_type(0), __b);
+        if (sycl::isnan(__c))
+          __c = sycl::copysign(value_type(0), __c);
+        if (sycl::isnan(__d))
+          __d = sycl::copysign(value_type(0), __d);
+        __recalc = true;
+      }
+      if (__recalc) {
+        __x = value_type(INFINITY) * (__a * __c - __b * __d);
+        __y = value_type(INFINITY) * (__a * __d + __b * __c);
+      }
+    }
+    return complex<value_type>(__x, __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(const complex<value_type> &__x, const value_type &__y) {
+    complex<value_type> __t(__x);
+    __t *= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(const value_type &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__y);
+    __t *= __x;
+    return __t;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(const complex<value_type> &__z, const complex<value_type> &__w) {
+    int __ilogbw = 0;
+    value_type __a = __z.real();
+    value_type __b = __z.imag();
+    value_type __c = __w.real();
+    value_type __d = __w.imag();
+    value_type __logbw = sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
+    if (sycl::isfinite(__logbw)) {
+      __ilogbw = static_cast<int>(__logbw);
+      __c = sycl::ldexp(__c, -__ilogbw);
+      __d = sycl::ldexp(__d, -__ilogbw);
+    }
+    value_type __denom = __c * __c + __d * __d;
+    value_type __x = sycl::ldexp((__a * __c + __b * __d) / __denom, -__ilogbw);
+    value_type __y = sycl::ldexp((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (sycl::isnan(__x) && sycl::isnan(__y)) {
+      if ((__denom == value_type(0)) && (!sycl::isnan(__a) || !sycl::isnan(__b))) {
+        __x = sycl::copysign(value_type(INFINITY), __c) * __a;
+        __y = sycl::copysign(value_type(INFINITY), __c) * __b;
+      } else if ((sycl::isinf(__a) || sycl::isinf(__b)) && sycl::isfinite(__c) &&
+                 sycl::isfinite(__d)) {
+        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0), __a);
+        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0), __b);
+        __x = value_type(INFINITY) * (__a * __c + __b * __d);
+        __y = value_type(INFINITY) * (__b * __c - __a * __d);
+      } else if (sycl::isinf(__logbw) && __logbw > value_type(0) &&
+                 sycl::isfinite(__a) && sycl::isfinite(__b)) {
+        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0), __c);
+        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0), __d);
+        __x = value_type(0) * (__a * __c + __b * __d);
+        __y = value_type(0) * (__b * __c - __a * __d);
+      }
+    }
+    return complex<value_type>(__x, __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(const complex<value_type> &__x, const value_type &__y) {
+    return complex<value_type>(__x.real() / __y, __x.imag() / __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(const value_type &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t /= __y;
+    return __t;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(const complex<value_type> &__x, const complex<value_type> &__y) {
+    return __x.real() == __y.real() && __x.imag() == __y.imag();
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(const complex<value_type> &__x, const value_type &__y) {
+    return __x.real() == __y && __x.imag() == 0;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(const value_type &__x, const complex<value_type> &__y) {
+    return __x == __y.real() && 0 == __y.imag();
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(const complex<value_type> &__x, const complex<value_type> &__y) {
+    return !(__x == __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(const complex<value_type> &__x, const value_type &__y) {
+    return !(__x == __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(const value_type &__x, const complex<value_type> &__y) {
+    return !(__x == __y);
+  }
+
+  template <class _CharT, class _Traits>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_istream<_CharT, _Traits>
+  &operator>>(std::basic_istream<_CharT, _Traits> &__is, complex<value_type> &__x) {
+    if (__is.good()) {
+      ws(__is);
+      if (__is.peek() == _CharT('(')) {
+        __is.get();
+        value_type __r;
+        __is >> __r;
+        if (!__is.fail()) {
+          ws(__is);
+          _CharT __c = __is.peek();
+          if (__c == _CharT(',')) {
+            __is.get();
+            value_type __i;
+            __is >> __i;
+            if (!__is.fail()) {
+              ws(__is);
+              __c = __is.peek();
+              if (__c == _CharT(')')) {
+                __is.get();
+                __x = complex<value_type>(__r, __i);
+              } else
+                __is.setstate(__is.failbit);
+            } else
+              __is.setstate(__is.failbit);
+          } else if (__c == _CharT(')')) {
+            __is.get();
+            __x = complex<value_type>(__r, value_type(0));
+          } else
+            __is.setstate(__is.failbit);
+        } else
+          __is.setstate(__is.failbit);
+      } else {
+        value_type __r;
+        __is >> __r;
+        if (!__is.fail())
+          __x = complex<value_type>(__r, value_type(0));
+        else
+          __is.setstate(__is.failbit);
+      }
+    } else
+      __is.setstate(__is.failbit);
+    return __is;
+  }
+
+  template <class _CharT, class _Traits>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_ostream<_CharT, _Traits>
+  &operator<<(std::basic_ostream<_CharT, _Traits> &__os, const complex<value_type> &__x) {
+    std::basic_ostringstream<_CharT, _Traits> __s;
+    __s.flags(__os.flags());
+    __s.imbue(__os.getloc());
+    __s.precision(__os.precision());
+    __s << '(' << __x.real() << ',' << __x.imag() << ')';
+    return __os << __s.str();
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend const sycl::stream
+  &operator<<(const sycl::stream &__ss, const complex<value_type> &_x) {
+    return __ss << "(" << _x.real() << "," << _x.imag() << ")";
   }
 };
-
-template <> class complex<float>;
-template <> class complex<double>;
-
-template <> class complex<sycl::half> {
-  sycl::half __re_;
-  sycl::half __im_;
-
-public:
-  typedef sycl::half value_type;
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      sycl::half __re = sycl::half{}, sycl::half __im = sycl::half{})
-      : __re_(__re), __im_(__im) {}
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  explicit constexpr complex(const complex<float> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  explicit constexpr complex(const complex<double> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr operator std::complex<sycl::half>() {
-    return std::complex<sycl::half>(__re_, __im_);
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr sycl::half real() const {
-    return __re_;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr sycl::half imag() const {
-    return __im_;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(sycl::half __re) {
-    __re_ = __re;
-    __im_ = value_type();
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(sycl::half __re) {
-    __re_ += __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(sycl::half __re) {
-    __re_ -= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(sycl::half __re) {
-    __re_ *= __re;
-    __im_ *= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(sycl::half __re) {
-    __re_ /= __re;
-    __im_ /= __re;
-    return *this;
-  }
-
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator=(const std::complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator+=(const complex<_Xp> &__c) {
-    __re_ += __c.real();
-    __im_ += __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator-=(const complex<_Xp> &__c) {
-    __re_ -= __c.real();
-    __im_ -= __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator*=(const complex<_Xp> &__c) {
-    *this = *this * complex(__c.real(), __c.imag());
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator/=(const complex<_Xp> &__c) {
-    *this = *this / complex(__c.real(), __c.imag());
-    return *this;
-  }
-};
-
-template <> class complex<float> {
-  float __re_;
-  float __im_;
-
-public:
-  typedef float value_type;
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(float __re = 0.0f,
-                                                     float __im = 0.0f)
-      : __re_(__re), __im_(__im) {}
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr complex(const complex<sycl::half> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  explicit constexpr complex(const complex<double> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr complex(const std::complex<float> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr operator std::complex<float>() {
-    return std::complex<float>(__re_, __im_);
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr float real() const {
-    return __re_;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr float imag() const {
-    return __im_;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(float __re) {
-    __re_ = __re;
-    __im_ = value_type();
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(float __re) {
-    __re_ += __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(float __re) {
-    __re_ -= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(float __re) {
-    __re_ *= __re;
-    __im_ *= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(float __re) {
-    __re_ /= __re;
-    __im_ /= __re;
-    return *this;
-  }
-
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator=(const std::complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator+=(const complex<_Xp> &__c) {
-    __re_ += __c.real();
-    __im_ += __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator-=(const complex<_Xp> &__c) {
-    __re_ -= __c.real();
-    __im_ -= __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator*=(const complex<_Xp> &__c) {
-    *this = *this * complex(__c.real(), __c.imag());
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator/=(const complex<_Xp> &__c) {
-    *this = *this / complex(__c.real(), __c.imag());
-    return *this;
-  }
-};
-
-template <> class complex<double> {
-  double __re_;
-  double __im_;
-
-public:
-  typedef double value_type;
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(double __re = 0.0,
-                                                     double __im = 0.0)
-      : __re_(__re), __im_(__im) {}
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr complex(const complex<sycl::half> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr complex(const complex<float> &__c);
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr complex(const std::complex<double> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  constexpr operator std::complex<double>() {
-    return std::complex<double>(__re_, __im_);
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr double real() const {
-    return __re_;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr double imag() const {
-    return __im_;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(double __re) {
-    __re_ = __re;
-    __im_ = value_type();
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(double __re) {
-    __re_ += __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(double __re) {
-    __re_ -= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(double __re) {
-    __re_ *= __re;
-    __im_ *= __re;
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(double __re) {
-    __re_ /= __re;
-    __im_ /= __re;
-    return *this;
-  }
-
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator=(const std::complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator+=(const complex<_Xp> &__c) {
-    __re_ += __c.real();
-    __im_ += __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator-=(const complex<_Xp> &__c) {
-    __re_ -= __c.real();
-    __im_ -= __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator*=(const complex<_Xp> &__c) {
-    *this = *this * complex(__c.real(), __c.imag());
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
-  operator/=(const complex<_Xp> &__c) {
-    *this = *this / complex(__c.real(), __c.imag());
-    return *this;
-  }
-};
-
-inline constexpr complex<sycl::half>::complex(const complex<float> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-inline constexpr complex<sycl::half>::complex(const complex<double> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-inline constexpr complex<float>::complex(const complex<sycl::half> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-inline constexpr complex<float>::complex(const complex<double> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-inline constexpr complex<double>::complex(const complex<sycl::half> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-inline constexpr complex<double>::complex(const complex<float> &__c)
-    : __re_(__c.real()), __im_(__c.imag()) {}
-
-// 26.3.6 operators:
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator+(const complex<_Tp> &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(__x);
-  __t += __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator+(const complex<_Tp> &__x,
-                                                        const _Tp &__y) {
-  complex<_Tp> __t(__x);
-  __t += __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator+(const _Tp &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(__y);
-  __t += __x;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator-(const complex<_Tp> &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(__x);
-  __t -= __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator-(const complex<_Tp> &__x,
-                                                        const _Tp &__y) {
-  complex<_Tp> __t(__x);
-  __t -= __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator-(const _Tp &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(-__y);
-  __t += __x;
-  return __t;
-}
-
-template <class _Tp>
-complex<_Tp> operator*(const complex<_Tp> &__z, const complex<_Tp> &__w) {
-  _Tp __a = __z.real();
-  _Tp __b = __z.imag();
-  _Tp __c = __w.real();
-  _Tp __d = __w.imag();
-  _Tp __ac = __a * __c;
-  _Tp __bd = __b * __d;
-  _Tp __ad = __a * __d;
-  _Tp __bc = __b * __c;
-  _Tp __x = __ac - __bd;
-  _Tp __y = __ad + __bc;
-  if (sycl::isnan(__x) && sycl::isnan(__y)) {
-    bool __recalc = false;
-    if (sycl::isinf(__a) || sycl::isinf(__b)) {
-      __a = sycl::copysign(sycl::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = sycl::copysign(sycl::isinf(__b) ? _Tp(1) : _Tp(0), __b);
-      if (sycl::isnan(__c))
-        __c = sycl::copysign(_Tp(0), __c);
-      if (sycl::isnan(__d))
-        __d = sycl::copysign(_Tp(0), __d);
-      __recalc = true;
-    }
-    if (sycl::isinf(__c) || sycl::isinf(__d)) {
-      __c = sycl::copysign(sycl::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = sycl::copysign(sycl::isinf(__d) ? _Tp(1) : _Tp(0), __d);
-      if (sycl::isnan(__a))
-        __a = sycl::copysign(_Tp(0), __a);
-      if (sycl::isnan(__b))
-        __b = sycl::copysign(_Tp(0), __b);
-      __recalc = true;
-    }
-    if (!__recalc && (sycl::isinf(__ac) || sycl::isinf(__bd) ||
-                      sycl::isinf(__ad) || sycl::isinf(__bc))) {
-      if (sycl::isnan(__a))
-        __a = sycl::copysign(_Tp(0), __a);
-      if (sycl::isnan(__b))
-        __b = sycl::copysign(_Tp(0), __b);
-      if (sycl::isnan(__c))
-        __c = sycl::copysign(_Tp(0), __c);
-      if (sycl::isnan(__d))
-        __d = sycl::copysign(_Tp(0), __d);
-      __recalc = true;
-    }
-    if (__recalc) {
-      __x = _Tp(INFINITY) * (__a * __c - __b * __d);
-      __y = _Tp(INFINITY) * (__a * __d + __b * __c);
-    }
-  }
-  return complex<_Tp>(__x, __y);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator*(const complex<_Tp> &__x,
-                                                        const _Tp &__y) {
-  complex<_Tp> __t(__x);
-  __t *= __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator*(const _Tp &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(__y);
-  __t *= __x;
-  return __t;
-}
-
-template <class _Tp>
-complex<_Tp> operator/(const complex<_Tp> &__z, const complex<_Tp> &__w) {
-  int __ilogbw = 0;
-  _Tp __a = __z.real();
-  _Tp __b = __z.imag();
-  _Tp __c = __w.real();
-  _Tp __d = __w.imag();
-  _Tp __logbw = sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
-  if (sycl::isfinite(__logbw)) {
-    __ilogbw = static_cast<int>(__logbw);
-    __c = sycl::ldexp(__c, -__ilogbw);
-    __d = sycl::ldexp(__d, -__ilogbw);
-  }
-  _Tp __denom = __c * __c + __d * __d;
-  _Tp __x = sycl::ldexp((__a * __c + __b * __d) / __denom, -__ilogbw);
-  _Tp __y = sycl::ldexp((__b * __c - __a * __d) / __denom, -__ilogbw);
-  if (sycl::isnan(__x) && sycl::isnan(__y)) {
-    if ((__denom == _Tp(0)) && (!sycl::isnan(__a) || !sycl::isnan(__b))) {
-      __x = sycl::copysign(_Tp(INFINITY), __c) * __a;
-      __y = sycl::copysign(_Tp(INFINITY), __c) * __b;
-    } else if ((sycl::isinf(__a) || sycl::isinf(__b)) && sycl::isfinite(__c) &&
-               sycl::isfinite(__d)) {
-      __a = sycl::copysign(sycl::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = sycl::copysign(sycl::isinf(__b) ? _Tp(1) : _Tp(0), __b);
-      __x = _Tp(INFINITY) * (__a * __c + __b * __d);
-      __y = _Tp(INFINITY) * (__b * __c - __a * __d);
-    } else if (sycl::isinf(__logbw) && __logbw > _Tp(0) &&
-               sycl::isfinite(__a) && sycl::isfinite(__b)) {
-      __c = sycl::copysign(sycl::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = sycl::copysign(sycl::isinf(__d) ? _Tp(1) : _Tp(0), __d);
-      __x = _Tp(0) * (__a * __c + __b * __d);
-      __y = _Tp(0) * (__b * __c - __a * __d);
-    }
-  }
-  return complex<_Tp>(__x, __y);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator/(const complex<_Tp> &__x,
-                                                        const _Tp &__y) {
-  return complex<_Tp>(__x.real() / __y, __x.imag() / __y);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator/(const _Tp &__x, const complex<_Tp> &__y) {
-  complex<_Tp> __t(__x);
-  __t /= __y;
-  return __t;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator+(const complex<_Tp> &__x) {
-  return __x;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-operator-(const complex<_Tp> &__x) {
-  return complex<_Tp>(-__x.real(), -__x.imag());
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator==(const complex<_Tp> &__x, const complex<_Tp> &__y) {
-  return __x.real() == __y.real() && __x.imag() == __y.imag();
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator==(const complex<_Tp> &__x, const _Tp &__y) {
-  return __x.real() == __y && __x.imag() == 0;
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator==(const _Tp &__x, const complex<_Tp> &__y) {
-  return __x == __y.real() && 0 == __y.imag();
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator!=(const complex<_Tp> &__x, const complex<_Tp> &__y) {
-  return !(__x == __y);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator!=(const complex<_Tp> &__x, const _Tp &__y) {
-  return !(__x == __y);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
-operator!=(const _Tp &__x, const complex<_Tp> &__y) {
-  return !(__x == __y);
-}
-
-// 26.3.7 values:
 
 template <class _Tp, bool = std::is_integral<_Tp>::value,
-          bool = std::is_floating_point<_Tp>::value>
+          bool = is_genfloat<_Tp>::value>
 struct __libcpp_complex_overload_traits {};
 
 // Integral Types
@@ -1038,18 +749,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp arg(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename std::enable_if<std::is_integral<_Tp>::value ||
-                                std::is_same<_Tp, double>::value,
-                            double>::type
-    arg(_Tp __re) {
-  return sycl::atan2(0., __re);
-}
-
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename std::enable_if<std::is_same<_Tp, float>::value, float>::type
-    arg(_Tp __re) {
-  return sycl::atan2(0.F, __re);
+typename __libcpp_complex_overload_traits<_Tp>::_ValueType arg(_Tp __re) {
+  typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+  return sycl::atan2<_ValueType>(0, __re);
 }
 
 // norm
@@ -1098,29 +800,23 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
 }
 
 template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
-    std::is_floating_point<_Tp>::value,
-    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
-proj(_Tp __re) {
-  if (sycl::isinf(__re))
-    __re = sycl::fabs(__re);
-  return complex<_Tp>(__re);
-}
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
+  typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
+  proj(_Tp __re) {
+  typedef typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
 
-template <class _Tp>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
-    std::is_integral<_Tp>::value,
-    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
-proj(_Tp __re) {
-  typedef
-      typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+  if constexpr(!std::is_integral_v<_Tp>) {
+    if (sycl::isinf(__re))
+      __re = sycl::fabs(__re);
+  }
+
   return _ComplexType(__re);
 }
 
 // polar
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   if (sycl::isnan(__theta)) {
@@ -1159,7 +855,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> log10(const complex<_Tp> &__x) {
 // sqrt
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> sqrt(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
   if (sycl::isinf(__x.real())) {
@@ -1176,7 +872,7 @@ complex<_Tp> sqrt(const complex<_Tp> &__x) {
 // exp
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> exp(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> exp(const complex<_Tp> &__x) {
   _Tp __i = __x.imag();
   if (__i == 0) {
     return complex<_Tp>(sycl::exp(__x.real()),
@@ -1232,6 +928,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY
   return pow(result_type(__x), result_type(__y));
 }
 
+namespace detail {
 // __sqr, computes pow(x, 2)
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
@@ -1239,11 +936,12 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
   return complex<_Tp>((__x.real() - __x.imag()) * (__x.real() + __x.imag()),
                       _Tp(2) * __x.real() * __x.imag());
 }
+}
 
 // asinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> asinh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> asinh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1263,7 +961,7 @@ complex<_Tp> asinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(sycl::copysign(__x.imag(), __x.real()),
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
-  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) + _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) + _Tp(1)));
   return complex<_Tp>(sycl::copysign(__z.real(), __x.real()),
                       sycl::copysign(__z.imag(), __x.imag()));
 }
@@ -1271,7 +969,7 @@ complex<_Tp> asinh(const complex<_Tp> &__x) {
 // acosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> acosh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> acosh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1296,7 +994,7 @@ complex<_Tp> acosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.imag()),
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
-  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) - _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) - _Tp(1)));
   return complex<_Tp>(sycl::copysign(__z.real(), _Tp(0)),
                       sycl::copysign(__z.imag(), __x.imag()));
 }
@@ -1304,7 +1002,7 @@ complex<_Tp> acosh(const complex<_Tp> &__x) {
 // atanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> atanh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> atanh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.imag())) {
     return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
@@ -1334,7 +1032,7 @@ complex<_Tp> atanh(const complex<_Tp> &__x) {
 // sinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> sinh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(__x.real(), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1348,7 +1046,7 @@ complex<_Tp> sinh(const complex<_Tp> &__x) {
 // cosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> cosh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1364,7 +1062,7 @@ complex<_Tp> cosh(const complex<_Tp> &__x) {
 // tanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> tanh(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> tanh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real())) {
     if (!sycl::isfinite(__x.imag()))
       return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()), _Tp(0));
@@ -1386,7 +1084,7 @@ complex<_Tp> tanh(const complex<_Tp> &__x) {
 // asin
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> asin(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> asin(const complex<_Tp> &__x) {
   complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1394,7 +1092,7 @@ complex<_Tp> asin(const complex<_Tp> &__x) {
 // acos
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-complex<_Tp> acos(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> acos(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1419,7 +1117,7 @@ complex<_Tp> acos(const complex<_Tp> &__x) {
     return complex<_Tp>(__pi / _Tp(2), -__x.imag());
   if (__x.real() == 0 && (__x.imag() == 0 || isnan(__x.imag())))
     return complex<_Tp>(__pi / _Tp(2), -__x.imag());
-  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) - _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) - _Tp(1)));
   if (sycl::signbit(__x.imag()))
     return complex<_Tp>(sycl::fabs(__z.imag()), sycl::fabs(__z.real()));
   return complex<_Tp>(sycl::fabs(__z.imag()), -sycl::fabs(__z.real()));
@@ -1454,69 +1152,6 @@ template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> tan(const complex<_Tp> &__x) {
   complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
-}
-
-template <class _Tp, class _CharT, class _Traits>
-std::basic_istream<_CharT, _Traits> &
-operator>>(std::basic_istream<_CharT, _Traits> &__is, complex<_Tp> &__x) {
-  if (__is.good()) {
-    ws(__is);
-    if (__is.peek() == _CharT('(')) {
-      __is.get();
-      _Tp __r;
-      __is >> __r;
-      if (!__is.fail()) {
-        ws(__is);
-        _CharT __c = __is.peek();
-        if (__c == _CharT(',')) {
-          __is.get();
-          _Tp __i;
-          __is >> __i;
-          if (!__is.fail()) {
-            ws(__is);
-            __c = __is.peek();
-            if (__c == _CharT(')')) {
-              __is.get();
-              __x = complex<_Tp>(__r, __i);
-            } else
-              __is.setstate(__is.failbit);
-          } else
-            __is.setstate(__is.failbit);
-        } else if (__c == _CharT(')')) {
-          __is.get();
-          __x = complex<_Tp>(__r, _Tp(0));
-        } else
-          __is.setstate(__is.failbit);
-      } else
-        __is.setstate(__is.failbit);
-    } else {
-      _Tp __r;
-      __is >> __r;
-      if (!__is.fail())
-        __x = complex<_Tp>(__r, _Tp(0));
-      else
-        __is.setstate(__is.failbit);
-    }
-  } else
-    __is.setstate(__is.failbit);
-  return __is;
-}
-
-template <class _Tp, class _CharT, class _Traits>
-std::basic_ostream<_CharT, _Traits> &
-operator<<(std::basic_ostream<_CharT, _Traits> &__os, const complex<_Tp> &__x) {
-  std::basic_ostringstream<_CharT, _Traits> __s;
-  __s.flags(__os.flags());
-  __s.imbue(__os.getloc());
-  __s.precision(__os.precision());
-  __s << '(' << __x.real() << ',' << __x.imag() << ')';
-  return __os << __s.str();
-}
-
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
-operator<<(const sycl::stream &__ss, const complex<_Tp> &_x) {
-  return __ss << "(" << _x.real() << "," << _x.imag() << ")";
 }
 
 _SYCL_EXT_CPLX_END_NAMESPACE_STD

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -271,7 +271,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
 
-namespace detail {
+namespace cplex::detail {
 template <class _Tp> struct __numeric_type {
   static void __test(...);
   static sycl::half __test(sycl::half);
@@ -690,7 +690,7 @@ public:
   }
 };
 
-namespace detail {
+namespace cplex::detail {
 template <class _Tp, bool = std::is_integral<_Tp>::value,
           bool = is_genfloat<_Tp>::value>
 struct __libcpp_complex_overload_traits {};
@@ -717,7 +717,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp real(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     real(_Tp __re) {
   return __re;
 }
@@ -731,7 +731,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp imag(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     imag(_Tp) {
   return 0;
 }
@@ -752,8 +752,8 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp arg(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType arg(_Tp __re) {
-  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType arg(_Tp __re) {
+  typedef typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
   return sycl::atan2<_ValueType>(0, __re);
 }
 
@@ -770,9 +770,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp norm(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
+    typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
     norm(_Tp __re) {
-  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+  typedef typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
   return static_cast<_ValueType>(__re) * __re;
 }
 
@@ -785,10 +785,10 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> conj(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
+    typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
     conj(_Tp __re) {
   typedef
-      typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+      typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
   return _ComplexType(__re);
 }
 
@@ -804,9 +804,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-  typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
+  typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType
   proj(_Tp __re) {
-  typedef typename detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+  typedef typename cplex::detail::__libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
 
   if constexpr(!std::is_integral_v<_Tp>) {
     if (sycl::isinf(__re))
@@ -905,9 +905,9 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp> &__x,
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename detail::__promote<_Tp, _Up>::type>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename cplex::detail::__promote<_Tp, _Up>::type>
 pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
-  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename cplex::detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
@@ -915,9 +915,9 @@ template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
-                            complex<typename detail::__promote<_Tp, _Up>::type>>::type
+                            complex<typename cplex::detail::__promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
-  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename cplex::detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
@@ -925,13 +925,13 @@ template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
-                            complex<typename detail::__promote<_Tp, _Up>::type>>::type
+                            complex<typename cplex::detail::__promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
-  typedef complex<typename detail::__promote<_Tp, _Up>::type> result_type;
+  typedef complex<typename cplex::detail::__promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
-namespace detail {
+namespace cplex::detail {
 // __sqr, computes pow(x, 2)
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
@@ -964,7 +964,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> asinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(sycl::copysign(__x.imag(), __x.real()),
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
-  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) + _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(cplex::detail::__sqr(__x) + _Tp(1)));
   return complex<_Tp>(sycl::copysign(__z.real(), __x.real()),
                       sycl::copysign(__z.imag(), __x.imag()));
 }
@@ -997,7 +997,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> acosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.imag()),
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
-  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) - _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(cplex::detail::__sqr(__x) - _Tp(1)));
   return complex<_Tp>(sycl::copysign(__z.real(), _Tp(0)),
                       sycl::copysign(__z.imag(), __x.imag()));
 }
@@ -1120,7 +1120,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> acos(const complex<_Tp> &__x) {
     return complex<_Tp>(__pi / _Tp(2), -__x.imag());
   if (__x.real() == 0 && (__x.imag() == 0 || isnan(__x.imag())))
     return complex<_Tp>(__pi / _Tp(2), -__x.imag());
-  complex<_Tp> __z = log(__x + sqrt(detail::__sqr(__x) - _Tp(1)));
+  complex<_Tp> __z = log(__x + sqrt(cplex::detail::__sqr(__x) - _Tp(1)));
   if (sycl::signbit(__x.imag()))
     return complex<_Tp>(sycl::fabs(__z.imag()), sycl::fabs(__z.real()));
   return complex<_Tp>(sycl::fabs(__z.imag()), -sycl::fabs(__z.real()));

--- a/tests/arg_complex.cpp
+++ b/tests/arg_complex.cpp
@@ -1,6 +1,6 @@
 #include "test_helper.hpp"
 
-TEMPLATE_TEST_CASE("Test complex arg", "[arg]", double, float, sycl::half) {
+TEMPLATE_TEST_CASE("Test complex arg cmplx", "[arg]", double, float, sycl::half) {
   using T = TestType;
 
   sycl::queue Q;
@@ -33,6 +33,48 @@ TEMPLATE_TEST_CASE("Test complex arg", "[arg]", double, float, sycl::half) {
 
   // Check cplx::complex output from host
   cplx_out[0] = sycl::ext::cplx::arg<T>(cplx_input);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE("Test complex arg deci", "[arg]",
+(std::pair<double, bool>),
+(std::pair<double, char>),
+(std::pair<double, int>),
+(std::pair<sycl::half, sycl::half>),
+(std::pair<float, float>),
+(std::pair<double, double>)) {
+
+  using T = typename TestType::first_type;
+  using X = typename TestType::second_type;
+
+  sycl::queue Q;
+
+  // Test cases
+  // Note: Output is undefined if val is Nan
+  X input = GENERATE(4.42, 2.02, inf_val<T>);
+
+  auto std_in = init_deci(input);
+
+  T std_out{};
+  auto *cplx_out = sycl::malloc_shared<T>(1, Q);
+
+  // Get std::complex output
+  std_out = std::arg(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<X>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::arg<X>(std_in);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::arg<X>(std_in);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/arg_complex.cpp
+++ b/tests/arg_complex.cpp
@@ -65,7 +65,7 @@ TEMPLATE_TEST_CASE("Test complex arg deci", "[arg]",
   std_out = std::arg(std_in);
 
   // Check cplx::complex output from device
-  if (is_type_supported<X>(Q)) {
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
        cplx_out[0] = sycl::ext::cplx::arg<X>(std_in);
      }).wait();

--- a/tests/arg_complex.cpp
+++ b/tests/arg_complex.cpp
@@ -67,14 +67,14 @@ TEMPLATE_TEST_CASE("Test complex arg deci", "[arg]",
   // Check cplx::complex output from device
   if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::arg<X>(std_in);
+       cplx_out[0] = sycl::ext::cplx::arg<X>(input);
      }).wait();
 
     check_results(cplx_out[0], std_out);
   }
 
   // Check cplx::complex output from host
-  cplx_out[0] = sycl::ext::cplx::arg<X>(std_in);
+  cplx_out[0] = sycl::ext::cplx::arg<X>(input);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/conj_complex.cpp
+++ b/tests/conj_complex.cpp
@@ -1,0 +1,81 @@
+#include "test_helper.hpp"
+
+TEMPLATE_TEST_CASE("Test complex conj cmplx", "[conj]", double, float, sycl::half) {
+  using T = TestType;
+
+  sycl::queue Q;
+
+  // Test cases
+  cmplx<T> input = GENERATE(
+      cmplx<T>{4.42, 2.02}, cmplx<T>{inf_val<T>, 2.02},
+      cmplx<T>{4.42, inf_val<T>}, cmplx<T>{inf_val<T>, inf_val<T>},
+      cmplx<T>{nan_val<T>, 2.02}, cmplx<T>{4.42, nan_val<T>},
+      cmplx<T>{nan_val<T>, nan_val<T>}, cmplx<T>{nan_val<T>, inf_val<T>},
+      cmplx<T>{inf_val<T>, nan_val<T>});
+
+  auto std_in = init_std_complex(input);
+  sycl::ext::cplx::complex<T> cplx_input{input.re, input.im};
+
+  std::complex<T> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+  // Get std::complex output
+  std_out = std::conj(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::conj<T>(cplx_input);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::conj<T>(cplx_input);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE("Test complex conj deci", "[conj]",
+(std::pair<double, bool>),
+(std::pair<double, char>),
+(std::pair<double, int>),
+(std::pair<sycl::half, sycl::half>),
+(std::pair<float, float>),
+(std::pair<double, double>)) {
+
+  using T = typename TestType::first_type;
+  using X = typename TestType::second_type;
+
+  sycl::queue Q;
+
+  // Test cases
+  X input = GENERATE(4.42, 2.02, inf_val<T>, nan_val<T>);
+
+  auto std_in = init_deci(input);
+
+  std::complex<T> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+  // Get std::complex output
+  std_out = std::conj(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<X>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::conj<X>(std_in);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::conj<X>(std_in);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}

--- a/tests/conj_complex.cpp
+++ b/tests/conj_complex.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE("Test complex conj deci", "[conj]",
   std_out = std::conj(std_in);
 
   // Check cplx::complex output from device
-  if (is_type_supported<X>(Q)) {
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
        cplx_out[0] = sycl::ext::cplx::conj<X>(std_in);
      }).wait();

--- a/tests/conj_complex.cpp
+++ b/tests/conj_complex.cpp
@@ -66,14 +66,14 @@ TEMPLATE_TEST_CASE("Test complex conj deci", "[conj]",
   // Check cplx::complex output from device
   if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::conj<X>(std_in);
+       cplx_out[0] = sycl::ext::cplx::conj<X>(input);
      }).wait();
 
     check_results(cplx_out[0], std_out);
   }
 
   // Check cplx::complex output from host
-  cplx_out[0] = sycl::ext::cplx::conj<X>(std_in);
+  cplx_out[0] = sycl::ext::cplx::conj<X>(input);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/norm_complex.cpp
+++ b/tests/norm_complex.cpp
@@ -63,7 +63,7 @@ TEMPLATE_TEST_CASE("Test complex norm deci", "[norm]",
   std_out = std::norm(std_in);
 
   // Check cplx::complex output from device
-  if (is_type_supported<X>(Q)) {
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
        cplx_out[0] = sycl::ext::cplx::norm<X>(std_in);
      }).wait();

--- a/tests/norm_complex.cpp
+++ b/tests/norm_complex.cpp
@@ -65,14 +65,14 @@ TEMPLATE_TEST_CASE("Test complex norm deci", "[norm]",
   // Check cplx::complex output from device
   if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::norm<X>(std_in);
+       cplx_out[0] = sycl::ext::cplx::norm<X>(input);
      }).wait();
 
     check_results(cplx_out[0], std_out);
   }
 
   // Check cplx::complex output from host
-  cplx_out[0] = sycl::ext::cplx::norm<X>(std_in);
+  cplx_out[0] = sycl::ext::cplx::norm<X>(input);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/norm_complex.cpp
+++ b/tests/norm_complex.cpp
@@ -1,6 +1,6 @@
 #include "test_helper.hpp"
 
-TEMPLATE_TEST_CASE("Test complex norm", "[norm]", double, float, sycl::half) {
+TEMPLATE_TEST_CASE("Test complex norm cmplx", "[norm]", double, float, sycl::half) {
   using T = TestType;
 
   sycl::queue Q;
@@ -32,6 +32,47 @@ TEMPLATE_TEST_CASE("Test complex norm", "[norm]", double, float, sycl::half) {
 
   // Check cplx::complex output from host
   cplx_out[0] = sycl::ext::cplx::norm<T>(cplx_input);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE("Test complex norm deci", "[norm]",
+(std::pair<double, bool>),
+(std::pair<double, char>),
+(std::pair<double, int>),
+(std::pair<sycl::half, sycl::half>),
+(std::pair<float, float>),
+(std::pair<double, double>)) {
+
+  using T = typename TestType::first_type;
+  using X = typename TestType::second_type;
+
+  sycl::queue Q;
+
+  // Test cases
+  X input = GENERATE(4.42, 2.02, inf_val<T>, nan_val<T>);
+
+  auto std_in = init_deci(input);
+
+  T std_out{};
+  auto *cplx_out = sycl::malloc_shared<T>(1, Q);
+
+  // Get std::complex output
+  std_out = std::norm(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<X>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::norm<X>(std_in);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::norm<X>(std_in);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/pow_complex.cpp
+++ b/tests/pow_complex.cpp
@@ -50,6 +50,60 @@ TEMPLATE_TEST_CASE("Test complex pow cplx-cplx overload", "[pow]", double,
   sycl::free(cplx_out, Q);
 }
 
+TEMPLATE_TEST_CASE("Test complex pow cplx<T>-cplx<U> overload", "[pow]",
+(std::pair<double, float>),
+(std::pair<float, sycl::half>),
+(std::pair<sycl::half, double>)) {
+
+  using T = typename TestType::first_type;
+  using X = typename TestType::second_type;
+
+  sycl::queue Q;
+
+  // Test cases
+  // Values are generated as cross product of input1 and input2's GENERATE list
+  cmplx<T> input1 = GENERATE(
+      cmplx<T>{4.42, 2.02}, cmplx<T>{inf_val<T>, 2.02},
+      cmplx<T>{4.42, inf_val<T>}, cmplx<T>{inf_val<T>, inf_val<T>},
+      cmplx<T>{nan_val<T>, 2.02}, cmplx<T>{4.42, nan_val<T>},
+      cmplx<T>{nan_val<T>, nan_val<T>}, cmplx<T>{nan_val<T>, inf_val<T>},
+      cmplx<T>{inf_val<T>, nan_val<T>});
+
+  cmplx<X> input2 = GENERATE(
+      cmplx<X>{4.42, 2.02}, cmplx<X>{inf_val<X>, 2.02},
+      cmplx<X>{4.42, inf_val<X>}, cmplx<X>{inf_val<X>, inf_val<X>},
+      cmplx<X>{nan_val<X>, 2.02}, cmplx<X>{4.42, nan_val<X>},
+      cmplx<X>{nan_val<X>, nan_val<X>}, cmplx<X>{nan_val<X>, inf_val<X>},
+      cmplx<X>{inf_val<X>, nan_val<X>});
+
+  auto std_in1 = init_std_complex(input1);
+  auto std_in2 = init_std_complex(input2);
+  sycl::ext::cplx::complex<T> cplx_input1{input1.re, input1.im};
+  sycl::ext::cplx::complex<X> cplx_input2{input2.re, input2.im};
+
+  std::complex<T> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+  // Get std::complex output
+  std_out = std::pow(std_in1, std_in2);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
 TEMPLATE_TEST_CASE("Test complex pow cplx-deci overload", "[pow]", double,
                    float, sycl::half) {
   using T = TestType;

--- a/tests/pow_complex.cpp
+++ b/tests/pow_complex.cpp
@@ -88,7 +88,7 @@ TEMPLATE_TEST_CASE("Test complex pow cplx<T>-cplx<U> overload", "[pow]",
   std_out = std::pow(std_in1, std_in2);
 
   // Check cplx::complex output from device
-  if (is_type_supported<T>(Q)) {
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
        cplx_out[0] = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
      }).wait();

--- a/tests/proj_complex.cpp
+++ b/tests/proj_complex.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE("Test complex proj deci", "[proj]",
   std_out = std::proj(std_in);
 
   // Check cplx::complex output from device
-  if (is_type_supported<X>(Q)) {
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
        cplx_out[0] = sycl::ext::cplx::proj<X>(std_in);
      }).wait();

--- a/tests/proj_complex.cpp
+++ b/tests/proj_complex.cpp
@@ -66,14 +66,14 @@ TEMPLATE_TEST_CASE("Test complex proj deci", "[proj]",
   // Check cplx::complex output from device
   if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) {
     Q.single_task([=]() {
-       cplx_out[0] = sycl::ext::cplx::proj<X>(std_in);
+       cplx_out[0] = sycl::ext::cplx::proj<X>(input);
      }).wait();
 
     check_results(cplx_out[0], std_out);
   }
 
   // Check cplx::complex output from host
-  cplx_out[0] = sycl::ext::cplx::proj<X>(std_in);
+  cplx_out[0] = sycl::ext::cplx::proj<X>(input);
 
   check_results(cplx_out[0], std_out);
 

--- a/tests/proj_complex.cpp
+++ b/tests/proj_complex.cpp
@@ -1,0 +1,81 @@
+#include "test_helper.hpp"
+
+TEMPLATE_TEST_CASE("Test complex proj cmplx", "[proj]", double, float, sycl::half) {
+  using T = TestType;
+
+  sycl::queue Q;
+
+  // Test cases
+  cmplx<T> input = GENERATE(
+      cmplx<T>{4.42, 2.02}, cmplx<T>{inf_val<T>, 2.02},
+      cmplx<T>{4.42, inf_val<T>}, cmplx<T>{inf_val<T>, inf_val<T>},
+      cmplx<T>{nan_val<T>, 2.02}, cmplx<T>{4.42, nan_val<T>},
+      cmplx<T>{nan_val<T>, nan_val<T>}, cmplx<T>{nan_val<T>, inf_val<T>},
+      cmplx<T>{inf_val<T>, nan_val<T>});
+
+  auto std_in = init_std_complex(input);
+  sycl::ext::cplx::complex<T> cplx_input{input.re, input.im};
+
+  std::complex<T> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+  // Get std::complex output
+  std_out = std::proj(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::proj<T>(cplx_input);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::proj<T>(cplx_input);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE("Test complex proj deci", "[proj]",
+(std::pair<double, bool>),
+(std::pair<double, char>),
+(std::pair<double, int>),
+(std::pair<sycl::half, sycl::half>),
+(std::pair<float, float>),
+(std::pair<double, double>)) {
+
+  using T = typename TestType::first_type;
+  using X = typename TestType::second_type;
+
+  sycl::queue Q;
+
+  // Test cases
+  X input = GENERATE(4.42, 2.02, inf_val<T>, nan_val<T>);
+
+  auto std_in = init_deci(input);
+
+  std::complex<T> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q);
+
+  // Get std::complex output
+  std_out = std::proj(std_in);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<X>(Q)) {
+    Q.single_task([=]() {
+       cplx_out[0] = sycl::ext::cplx::proj<X>(std_in);
+     }).wait();
+
+    check_results(cplx_out[0], std_out);
+  }
+
+  // Check cplx::complex output from host
+  cplx_out[0] = sycl::ext::cplx::proj<X>(std_in);
+
+  check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}

--- a/tests/test_complex_types.cpp
+++ b/tests/test_complex_types.cpp
@@ -52,19 +52,14 @@ TEST_MATH_FUNC_TYPE("Test complex tan types", "[tan]", tan)
 TEST_MATH_FUNC_TYPE("Test complex tanh types", "[tanh]", tanh)
 #undef TEST_MATH_FUNC_TYPE
 
-TEMPLATE_TEST_CASE("Test complex abs types", "[abs]", double, float,
-                   sycl::half) {
-  static_assert(std::is_same_v<TestType, decltype(abs(complex<TestType>()))>);
-}
-
-TEMPLATE_TEST_CASE("Test complex polar types", "[abs]", double, float,
+TEMPLATE_TEST_CASE("Test complex polar types", "[polar]", double, float,
                    sycl::half) {
   static_assert(std::is_same_v<complex<TestType>, decltype(polar(TestType()))>);
   static_assert(std::is_same_v<complex<TestType>,
                                decltype(polar(TestType(), TestType()))>);
 }
 
-TEMPLATE_TEST_CASE("Test complex pow types", "[abs]", double, float,
+TEMPLATE_TEST_CASE("Test complex pow types", "[pow]", double, float,
                    sycl::half) {
   static_assert(std::is_same_v<complex<TestType>,
                                decltype(pow(complex<TestType>(), TestType()))>);
@@ -74,3 +69,54 @@ TEMPLATE_TEST_CASE("Test complex pow types", "[abs]", double, float,
   static_assert(std::is_same_v<complex<TestType>,
                                decltype(pow(TestType(), complex<TestType>()))>);
 }
+
+// Test F(Complex<T>) -> T
+#define TEST_FUNC_TYPE(test_name, label, func) \
+TEMPLATE_TEST_CASE(test_name, label, double, float, sycl::half) { \
+  static_assert(std::is_same_v<TestType, decltype(func(complex<TestType>()))>); \
+}
+
+TEST_FUNC_TYPE("Test complex abs deci - cplx types", "[abs]", abs)
+TEST_FUNC_TYPE("Test complex real deci - cplx types", "[real]", real)
+TEST_FUNC_TYPE("Test complex imag deci - cplx  types", "[imag]", imag)
+#undef TEST_FUNC_TYPE
+
+// Test F(T) -> T
+#define TEST_FUNC_TYPE(test_name, label, func) \
+TEMPLATE_TEST_CASE(test_name, label, \
+(std::pair<double, bool>), \
+(std::pair<double, char>), \
+(std::pair<double, int>), \
+(std::pair<sycl::half, sycl::half>), \
+(std::pair<double, double>), \
+(std::pair<float, float>)) { \
+  using T = typename TestType::first_type; \
+  using X = typename TestType::second_type; \
+ \
+  static_assert(std::is_same_v<T, decltype(func(X()))>); \
+}
+
+TEST_FUNC_TYPE("Test complex arg deci - deci types", "[arg]", arg)
+TEST_FUNC_TYPE("Test complex norm deci - deci types", "[norm]", norm)
+TEST_FUNC_TYPE("Test complex real deci - deci types", "[real]", real)
+TEST_FUNC_TYPE("Test complex imag deci - deci types", "[imag]", imag)
+#undef TEST_FUNC_TYPE
+
+// Test F(T) -> complex<T>
+#define TEST_FUNC_TYPE(test_name, label, func) \
+TEMPLATE_TEST_CASE(test_name, label, \
+(std::pair<double, bool>), \
+(std::pair<double, char>), \
+(std::pair<double, int>), \
+(std::pair<sycl::half, sycl::half>), \
+(std::pair<double, double>), \
+(std::pair<float, float>)) { \
+  using T = typename TestType::first_type; \
+  using X = typename TestType::second_type; \
+ \
+  static_assert(std::is_same_v<complex<T>, decltype(func(X()))>); \
+}
+
+TEST_FUNC_TYPE("Test complex conj cplx - deci types", "[conj]", conj)
+TEST_FUNC_TYPE("Test complex proj cplx - deci types", "[proj]", proj)
+#undef TEST_FUNC_TYPE

--- a/tests/test_free_functions.cpp
+++ b/tests/test_free_functions.cpp
@@ -1,0 +1,85 @@
+#include "test_helper.hpp"
+
+#define test_free_functions(test_name, label, func) \
+TEMPLATE_TEST_CASE(test_name, label, double, float, sycl::half) { \
+  using T = TestType; \
+ \
+  sycl::queue Q; \
+ \
+  cmplx<T> input = GENERATE( \
+      cmplx<T>{4.42, 2.02}, cmplx<T>{inf_val<T>, 2.02}, \
+      cmplx<T>{4.42, inf_val<T>}, cmplx<T>{inf_val<T>, inf_val<T>}, \
+      cmplx<T>{nan_val<T>, 2.02}, cmplx<T>{4.42, nan_val<T>}, \
+      cmplx<T>{nan_val<T>, nan_val<T>}, cmplx<T>{nan_val<T>, inf_val<T>}, \
+      cmplx<T>{inf_val<T>, nan_val<T>}); \
+ \
+  auto std_in = init_std_complex(input); \
+  sycl::ext::cplx::complex<T> cplx_input{input.re, input.im}; \
+ \
+  std::complex<T> std_out{}; \
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q); \
+ \
+  std_out = std::func(std_in); \
+ \
+  if (is_type_supported<T>(Q) && is_type_supported<T>(Q)) { \
+    Q.single_task([=]() { \
+       cplx_out[0] = sycl::ext::cplx::func<T>(cplx_input); \
+     }).wait(); \
+ \
+    check_results(cplx_out[0], std_out); \
+  } \
+ \
+  cplx_out[0] = sycl::ext::cplx::func<T>(cplx_input); \
+ \
+  check_results(cplx_out[0], std_out); \
+ \
+  sycl::free(cplx_out, Q); \
+}
+
+test_free_functions("Test free function real cplx", "[real]", real);
+test_free_functions("Test free function imag cplx", "[imag]", imag);
+
+#undef test_free_functions
+
+#define test_free_functions(test_name, label, func) \
+TEMPLATE_TEST_CASE(test_name, label, \
+(std::pair<double, bool>), \
+(std::pair<double, char>), \
+(std::pair<double, int>), \
+(std::pair<sycl::half, sycl::half>), \
+(std::pair<float, float>), \
+(std::pair<double, double>)) { \
+ \
+  using T = typename TestType::first_type; \
+  using X = typename TestType::second_type; \
+ \
+  sycl::queue Q; \
+ \
+  X input = GENERATE(4.42, 2.02, inf_val<T>, nan_val<T>); \
+ \
+  auto std_in = init_deci(input); \
+ \
+  std::complex<T> std_out{}; \
+  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q); \
+ \
+  std_out = std::func(std_in); \
+ \
+  if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) { \
+    Q.single_task([=]() { \
+       cplx_out[0] = sycl::ext::cplx::func<X>(std_in); \
+     }).wait(); \
+ \
+    check_results(cplx_out[0], std_out); \
+  } \
+ \
+  cplx_out[0] = sycl::ext::cplx::func<X>(std_in); \
+ \
+  check_results(cplx_out[0], std_out); \
+ \
+  sycl::free(cplx_out, Q); \
+}
+
+test_free_functions("Test free function real deci", "[real]", real);
+test_free_functions("Test free function imag deci", "[imag]", imag);
+
+#undef test_free_functions

--- a/tests/test_free_functions.cpp
+++ b/tests/test_free_functions.cpp
@@ -16,8 +16,8 @@ TEMPLATE_TEST_CASE(test_name, label, double, float, sycl::half) { \
   auto std_in = init_std_complex(input); \
   sycl::ext::cplx::complex<T> cplx_input{input.re, input.im}; \
  \
-  std::complex<T> std_out{}; \
-  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q); \
+  T std_out{}; \
+  auto *cplx_out = sycl::malloc_shared<T>(1, Q); \
  \
   std_out = std::func(std_in); \
  \
@@ -59,20 +59,20 @@ TEMPLATE_TEST_CASE(test_name, label, \
  \
   auto std_in = init_deci(input); \
  \
-  std::complex<T> std_out{}; \
-  auto *cplx_out = sycl::malloc_shared<sycl::ext::cplx::complex<T>>(1, Q); \
+  T std_out{}; \
+  auto *cplx_out = sycl::malloc_shared<T>(1, Q); \
  \
   std_out = std::func(std_in); \
  \
   if (is_type_supported<T>(Q) && is_type_supported<X>(Q)) { \
     Q.single_task([=]() { \
-       cplx_out[0] = sycl::ext::cplx::func<X>(std_in); \
+       cplx_out[0] = sycl::ext::cplx::func<X>(input); \
      }).wait(); \
  \
     check_results(cplx_out[0], std_out); \
   } \
  \
-  cplx_out[0] = sycl::ext::cplx::func<X>(std_in); \
+  cplx_out[0] = sycl::ext::cplx::func<X>(input); \
  \
   check_results(cplx_out[0], std_out); \
  \


### PR DESCRIPTION
This PR updates the complex implementation as well as the tests.

From the POV of the complex's user, the interface does not change.

The modification made to the implementation are:
 - the operators are now declared as hidden friends.
 - encapsulation of helper functions of the implementation (only expose what needs to be)
 - using metaprogramming to specialize the complex when the trait `genfloat` is true, which removes the duplication of operators
 - using metaprogramming to specialize different math operations when the trait `genfloat` is true, which removes some boilerplate code
 - add the missing attribute to different functions
 - remove const and ref keywords on `value_type`
 - add missing enable_if on free functions

The modifications made to the tests are:
- fix different typos
- add more tests