### PR TITLE
Introduction of marray's complex specialization

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -256,8 +256,12 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_EXT_CPLX_FAST_MATH
 #endif
 
+#define _SYCL_BEGIN_NAMESPACE namespace sycl {
+#define _SYCL_END_NAMESPACE }
+
 #define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace _SYCL_CPLX_NAMESPACE {
 #define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
+
 #define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
   [[gnu::always_inline]] [[clang::always_inline]] inline
 
@@ -364,6 +368,10 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isinf(const T a) {
 #endif
 }
 } // namespace cplex::detail
+
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX IMPLEMENTATION
+////////////////////////////////////////////////////////////////////////////////
 
 template <class _Tp, class _Enable = void> class complex;
 
@@ -1231,6 +1239,436 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> tan(const complex<_Tp> &__x) {
 }
 
 _SYCL_EXT_CPLX_END_NAMESPACE_STD
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY IMPLEMENTATION
+////////////////////////////////////////////////////////////////////////////////
+
+_SYCL_BEGIN_NAMESPACE
+
+// marray of complex class specialisation
+template <typename T, std::size_t NumElements>
+class marray<sycl::ext::cplx::complex<T>, NumElements> {
+private:
+  using DataT = sycl::ext::cplx::complex<T>;
+
+public:
+  using value_type = DataT;
+  using reference = DataT &;
+  using const_reference = const DataT &;
+  using iterator = DataT *;
+  using const_iterator = const DataT *;
+
+private:
+  value_type MData[NumElements];
+
+public:
+  constexpr marray() : MData{} {};
+
+  explicit constexpr marray(const DataT &arg) {
+    for (size_t i = 0; i < NumElements; ++i)
+      MData[i] = arg;
+  }
+
+  template <typename... ArgTN>
+  constexpr marray(const ArgTN &... args) : MData{args...} {};
+
+  constexpr marray(const marray<DataT, NumElements> &rhs) = default;
+  constexpr marray(marray<DataT, NumElements> &&rhs) = default;
+
+  // Available only when: NumElements == 1
+  template <typename = typename std::enable_if<NumElements == 1>>
+  operator DataT() const {
+    return MData[0];
+  }
+
+  static constexpr std::size_t size() noexcept { return NumElements; }
+
+  marray<T, NumElements> real() const {
+    sycl::marray<T, NumElements> rtn;
+
+    for (std::size_t i = 0; i < NumElements; ++i) {
+      rtn[i] = MData[i].real();
+    }
+
+    return rtn;
+  }
+
+  marray<T, NumElements> imag() const {
+    sycl::marray<T, NumElements> rtn;
+
+    for (std::size_t i = 0; i < NumElements; ++i) {
+      rtn[i] = MData[i].imag();
+    }
+
+    return rtn;
+  }
+
+  // subscript operator
+  reference operator[](std::size_t index) { return MData[index]; }
+  const_reference operator[](std::size_t index) const { return MData[index]; }
+
+  marray &operator=(const marray<DataT, NumElements> &rhs) = default;
+  marray &operator=(const DataT &rhs) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      MData[i] = rhs;
+
+    return *this;
+  }
+
+  // iterator functions
+  iterator begin() { return MData; }
+  const_iterator begin() const { return MData; }
+
+  iterator end() { return MData + NumElements; }
+  const_iterator end() const { return MData + NumElements; }
+
+  // OP is: +, -, *, /
+#define OP(op)                                                                 \
+  friend marray operator op(const marray &lhs, const marray &rhs) {            \
+    marray rtn;                                                                \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs[i] op rhs[i];                                               \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  friend marray operator op(const marray &lhs, const DataT &rhs) {             \
+    marray rtn;                                                                \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs[i] op rhs;                                                  \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  friend marray operator op(const DataT &lhs, const marray &rhs) {             \
+    marray rtn;                                                                \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs op rhs[i];                                                  \
+                                                                               \
+    return rtn;                                                                \
+  }
+
+  OP(+)
+  OP(-)
+  OP(*)
+  OP(/)
+
+#undef OP
+
+  // OP is: %
+  friend marray operator%(const marray &lhs, const marray &rhs) = delete;
+  friend marray operator%(const marray &lhs, const DataT &rhs) = delete;
+  friend marray operator%(const DataT &lhs, const marray &rhs) = delete;
+
+  // OP is: +=, -=, *=, /=
+#define OP(op)                                                                 \
+  friend marray &operator op(marray &lhs, const marray &rhs) {                 \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      lhs[i] op rhs[i];                                                        \
+                                                                               \
+    return lhs;                                                                \
+  }                                                                            \
+                                                                               \
+  friend marray &operator op(marray &lhs, const DataT &rhs) {                  \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      lhs[i] op rhs;                                                           \
+                                                                               \
+    return lhs;                                                                \
+  }                                                                            \
+  friend marray &operator op(DataT &lhs, const marray &rhs) {                  \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      lhs[i] op rhs;                                                           \
+                                                                               \
+    return lhs;                                                                \
+  }
+
+  OP(+=)
+  OP(-=)
+  OP(*=)
+  OP(/=)
+
+#undef OP
+
+  // OP is: %=
+  friend marray &operator%=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator%=(marray &lhs, const DataT &rhs) = delete;
+  friend marray &operator%=(DataT &lhs, const marray &rhs) = delete;
+
+// OP is: ++, --
+#define OP(op)                                                                 \
+  friend marray operator op(marray &lhs, int) = delete;                        \
+  friend marray &operator op(marray &rhs) = delete;
+
+  OP(++)
+  OP(--)
+
+#undef OP
+
+// OP is: unary +, unary -
+#define OP(op)                                                                 \
+  friend marray<DataT, NumElements> operator op(                               \
+      const marray<DataT, NumElements> &rhs) {                                 \
+    marray<DataT, NumElements> rtn;                                            \
+                                                                               \
+    for (std::size_t i = 0; i < NumElements; ++i) {                            \
+      rtn[i] = op rhs[i];                                                      \
+    }                                                                          \
+                                                                               \
+    return rtn;                                                                \
+  }
+
+  OP(+)
+  OP(-)
+
+#undef OP
+
+// OP is: &, |, ^
+#define OP(op)                                                                 \
+  friend marray operator op(const marray &lhs, const marray &rhs) = delete;    \
+  friend marray operator op(const marray &lhs, const DataT &rhs) = delete;
+
+  OP(&)
+  OP(|)
+  OP(^)
+
+#undef OP
+
+// OP is: &=, |=, ^=
+#define OP(op)                                                                 \
+  friend marray &operator op(marray &lhs, const marray &rhs) = delete;         \
+  friend marray &operator op(marray &lhs, const DataT &rhs) = delete;          \
+  friend marray &operator op(DataT &lhs, const marray &rhs) = delete;
+
+  OP(&=)
+  OP(|=)
+  OP(^=)
+
+#undef OP
+
+// OP is: &&, ||
+#define OP(op)                                                                 \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const marray &rhs) = delete;    \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const DataT &rhs) = delete;     \
+  friend marray<bool, NumElements> operator op(const DataT &lhs,               \
+                                               const marray &rhs) = delete;
+
+  OP(&&)
+  OP(||)
+
+#undef OP
+
+// OP is: <<, >>
+#define OP(op)                                                                 \
+  friend marray operator op(const marray &lhs, const marray &rhs) = delete;    \
+  friend marray operator op(const marray &lhs, const DataT &rhs) = delete;     \
+  friend marray operator op(const DataT &lhs, const marray &rhs) = delete;
+
+  OP(<<)
+  OP(>>)
+
+#undef OP
+
+// OP is: <<=, >>=
+#define OP(op)                                                                 \
+  friend marray &operator op(marray &lhs, const marray &rhs) = delete;         \
+  friend marray &operator op(marray &lhs, const DataT &rhs) = delete;
+
+  OP(<<=)
+  OP(>>=)
+
+#undef OP
+
+  // OP is: ==, !=
+#define OP(op)                                                                 \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const marray &rhs) {            \
+    marray<bool, NumElements> rtn;                                             \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs[i] op rhs[i];                                               \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const DataT &rhs) {             \
+    marray<bool, NumElements> rtn;                                             \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs[i] op rhs;                                                  \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  friend marray<bool, NumElements> operator op(const DataT &lhs,               \
+                                               const marray &rhs) {            \
+    marray<bool, NumElements> rtn;                                             \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = lhs op rhs[i];                                                  \
+                                                                               \
+    return rtn;                                                                \
+  }
+
+  OP(==)
+  OP(!=)
+
+#undef OP
+
+  // OP is: <, >, <=, >=
+#define OP(op)                                                                 \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const marray &rhs) = delete;    \
+  friend marray<bool, NumElements> operator op(const marray &lhs,              \
+                                               const DataT &rhs) = delete;     \
+  friend marray<bool, NumElements> operator op(const DataT &lhs,               \
+                                               const marray &rhs) = delete;
+
+  OP(<);
+  OP(>);
+  OP(<=);
+  OP(>=);
+
+#undef OP
+
+  friend marray operator~(const marray &v) = delete;
+
+  friend marray<bool, NumElements> operator!(const marray &v) = delete;
+};
+
+_SYCL_END_NAMESPACE
+
+_SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
+
+// Math marray overloads
+
+#define MATH_OP_ONE_PARAM(math_func, rtn_type, arg_type)                       \
+  template <typename T, std::size_t NumElements,                               \
+            typename = std::enable_if<is_genfloat<T>::value ||                 \
+                                      is_gencomplex<T>::value>>                \
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY sycl::marray<rtn_type, NumElements>         \
+  math_func(const sycl::marray<arg_type, NumElements> &x) {                    \
+    sycl::marray<rtn_type, NumElements> rtn;                                   \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = sycl::ext::cplx::math_func(x[i]);                               \
+                                                                               \
+    return rtn;                                                                \
+  }
+
+MATH_OP_ONE_PARAM(abs, T, complex<T>);
+MATH_OP_ONE_PARAM(acos, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(asin, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(atan, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(acosh, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(asinh, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(atanh, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(arg, T, complex<T>);
+MATH_OP_ONE_PARAM(conj, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(cos, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(cosh, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(exp, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(log, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(log10, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(norm, T, complex<T>);
+MATH_OP_ONE_PARAM(proj, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(proj, complex<T>, T);
+MATH_OP_ONE_PARAM(sin, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(sinh, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(sqrt, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(tan, complex<T>, complex<T>);
+MATH_OP_ONE_PARAM(tanh, complex<T>, complex<T>);
+
+#undef MATH_OP_ONE_PARAM
+
+#define MATH_OP_TWO_PARAM(math_func, rtn_type, arg_type1, arg_type2)           \
+  template <typename T, std::size_t NumElements,                               \
+            typename = std::enable_if<is_genfloat<T>::value ||                 \
+                                      is_gencomplex<T>::value>>                \
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY sycl::marray<rtn_type, NumElements>         \
+  math_func(const sycl::marray<arg_type1, NumElements> &x,                     \
+            const sycl::marray<arg_type2, NumElements> &y) {                   \
+    sycl::marray<rtn_type, NumElements> rtn;                                   \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = sycl::ext::cplx::math_func(x[i], y[i]);                         \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  template <typename T, std::size_t NumElements,                               \
+            typename = std::enable_if<is_genfloat<T>::value ||                 \
+                                      is_gencomplex<T>::value>>                \
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY sycl::marray<rtn_type, NumElements>         \
+  math_func(const sycl::marray<arg_type1, NumElements> &x,                     \
+            const arg_type2 &y) {                                              \
+    sycl::marray<rtn_type, NumElements> rtn;                                   \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = sycl::ext::cplx::math_func(x[i], y);                            \
+                                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+                                                                               \
+  template <typename T, std::size_t NumElements,                               \
+            typename = std::enable_if<is_genfloat<T>::value ||                 \
+                                      is_gencomplex<T>::value>>                \
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY sycl::marray<rtn_type, NumElements>         \
+  math_func(const arg_type1 &x,                                                \
+            const sycl::marray<arg_type2, NumElements> &y) {                   \
+    sycl::marray<rtn_type, NumElements> rtn;                                   \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      rtn[i] = math_func(x, y[i]);                                             \
+                                                                               \
+    return rtn;                                                                \
+  }
+
+MATH_OP_TWO_PARAM(pow, complex<T>, complex<T>, T);
+MATH_OP_TWO_PARAM(pow, complex<T>, complex<T>, complex<T>);
+MATH_OP_TWO_PARAM(pow, complex<T>, T, complex<T>);
+
+#undef MATH_OP_TWO_PARAM
+
+// Special definition as polar requires default argument
+
+template <typename T, std::size_t NumElements,
+          typename = std::enable_if<is_genfloat<T>::value>>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
+    sycl::marray<sycl::ext::cplx::complex<T>, NumElements>
+    polar(const sycl::marray<T, NumElements> &rho,
+          const sycl::marray<T, NumElements> &theta) {
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> rtn;
+  for (std::size_t i = 0; i < NumElements; ++i)
+    rtn[i] = sycl::ext::cplx::polar(rho[i], theta[i]);
+
+  return rtn;
+}
+
+template <typename T, std::size_t NumElements,
+          typename = std::enable_if<is_genfloat<T>::value>>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
+    sycl::marray<sycl::ext::cplx::complex<T>, NumElements>
+    polar(const sycl::marray<T, NumElements> &rho, const T &theta = 0) {
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> rtn;
+  for (std::size_t i = 0; i < NumElements; ++i)
+    rtn[i] = sycl::ext::cplx::polar(rho[i], theta);
+
+  return rtn;
+}
+
+template <typename T, std::size_t NumElements,
+          typename = std::enable_if<is_genfloat<T>::value>>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
+    sycl::marray<sycl::ext::cplx::complex<T>, NumElements>
+    polar(const T &rho, const sycl::marray<T, NumElements> &theta) {
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> rtn;
+  for (std::size_t i = 0; i < NumElements; ++i)
+    rtn[i] = sycl::ext::cplx::polar(rho, theta[i]);
+
+  return rtn;
+}
+
+_SYCL_EXT_CPLX_END_NAMESPACE_STD
+
+#undef _SYCL_BEGIN_NAMESPACE
+#undef _SYCL_END_NAMESPACE
 
 #undef _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
 #undef _SYCL_EXT_CPLX_END_NAMESPACE_STD

--- a/tests/abs_complex.cpp
+++ b/tests/abs_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex abs", "[abs]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,65 @@ TEMPLATE_TEST_CASE("Test complex abs", "[abs]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::abs<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex abs", "[abs]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<T, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::marray<T, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::abs(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::abs<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::abs<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/acos_complex.cpp
+++ b/tests/acos_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex acos", "[acos]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -55,4 +59,122 @@ TEMPLATE_TEST_CASE("Test complex acos", "[acos]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 2);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::acos(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::acos<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::cos<T>(sycl::ext::cplx::acos<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 4);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::acos<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::cos<T>(sycl::ext::cplx::acos<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex acos (check error: false)",
+                       "[acos]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex acos (check error: true)", "[acos]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/acosh_complex.cpp
+++ b/tests/acosh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex acosh", "[acosh]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -56,4 +60,123 @@ TEMPLATE_TEST_CASE("Test complex acosh", "[acosh]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 2);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::acosh(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::acosh<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::cosh<T>(sycl::ext::cplx::acosh<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 4);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::acosh<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::cosh<T>(sycl::ext::cplx::acosh<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex acosh (check error: false)",
+                       "[acosh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex acosh (check error: true)",
+                       "[acosh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/arg_complex.cpp
+++ b/tests/arg_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex arg cmplx", "[arg]", double, float,
                    sycl::half) {
   using T = TestType;
@@ -75,6 +79,65 @@ TEMPLATE_TEST_CASE("Test complex arg deci", "[arg]", (std::pair<double, bool>),
   cplx_out[0] = sycl::ext::cplx::arg<X>(input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex arg", "[arg]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<T, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::marray<T, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::arg(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::arg<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::arg<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/asin_complex.cpp
+++ b/tests/asin_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex asin", "[asin]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -55,4 +59,121 @@ TEMPLATE_TEST_CASE("Test complex asin", "[asin]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 6);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::asin(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::asin<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::sin<T>(sycl::ext::cplx::asin<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 6);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::asin<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::sin<T>(sycl::ext::cplx::asin<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 6);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex asin (check error: false)",
+                       "[asin]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex asin (check error: true)", "[asin]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/asinh_complex.cpp
+++ b/tests/asinh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex asinh", "[asinh]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -56,4 +60,122 @@ TEMPLATE_TEST_CASE("Test complex asinh", "[asinh]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 2);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::asinh(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::asinh<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::sinh<T>(sycl::ext::cplx::asinh<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 4);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::asinh<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::sinh<T>(sycl::ext::cplx::asinh<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 3);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex asinh (check error: false)",
+                       "[asinh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex asinh (check error: true)",
+                       "[asinh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/atan_complex.cpp
+++ b/tests/atan_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex atan", "[atan]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -55,4 +59,121 @@ TEMPLATE_TEST_CASE("Test complex atan", "[atan]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 2);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::atan(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::atan<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::tan<T>(sycl::ext::cplx::atan<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::atan<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::tan<T>(sycl::ext::cplx::atan<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex atan (check error: false)",
+                       "[atan]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex atan (check error: true)", "[atan]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/atanh_complex.cpp
+++ b/tests/atanh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex atanh", "[atanh]", double, float, sycl::half) {
   using T = TestType;
   using std::make_tuple;
@@ -56,4 +60,122 @@ TEMPLATE_TEST_CASE("Test complex atanh", "[atanh]", double, float, sycl::half) {
   check_results(cplx_out[0], std_out, /*tol_multiplier*/ 2);
 
   sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename X, std::size_t NumElements>
+auto test(
+    sycl::queue &Q, const sycl::marray<std::complex<X>, NumElements> &std_in,
+    const sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input,
+    bool is_error_checking) {
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  if (is_error_checking) {
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std::atanh(std_in[i]);
+  } else {
+    // Need to manually copy to handle as for for halfs, std_in is of value
+    // type float and std_out is of value type half
+    for (std::size_t i = 0; i < NumElements; ++i)
+      std_out[i] = std_in[i];
+  }
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    if (is_error_checking) {
+      Q.single_task([=]() {
+         *cplx_out = sycl::ext::cplx::atanh<T>(cplx_input);
+       }).wait();
+    } else {
+      Q.single_task([=]() {
+         *cplx_out =
+             sycl::ext::cplx::tanh<T>(sycl::ext::cplx::atanh<T>(cplx_input));
+       }).wait();
+    }
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+  }
+
+  // Check cplx::complex output from host
+  if (is_error_checking) {
+    *cplx_out = sycl::ext::cplx::atanh<T>(cplx_input);
+  } else {
+    *cplx_out = sycl::ext::cplx::tanh<T>(sycl::ext::cplx::atanh<T>(cplx_input));
+  }
+
+  check_results(*cplx_out, std_out, /*tol_multiplier*/ 2);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex atanh (check error: false)",
+                       "[atanh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 4), (float, 4), (sycl::half, 4)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 2.5},
+          std::complex<T>{4.0, -4.0},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, false);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex atanh (check error: true)",
+                       "[atanh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  // sycl::half cases are emulated with float for std::complex class (std_in)
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+  test<T, X>(Q, std_in, cplx_input, true);
 }

--- a/tests/conj_complex.cpp
+++ b/tests/conj_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex conj cmplx", "[conj]", double, float,
                    sycl::half) {
   using T = TestType;
@@ -75,6 +79,66 @@ TEMPLATE_TEST_CASE("Test complex conj deci", "[conj]",
   cplx_out[0] = sycl::ext::cplx::conj<X>(input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex conj", "[conj]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::conj(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::conj<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::conj<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/cos_complex.cpp
+++ b/tests/cos_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex cos", "[cos]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex cos", "[cos]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::cos<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex cos", "[cos]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::cos(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::cos<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::cos<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/cosh_complex.cpp
+++ b/tests/cosh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex cosh", "[cosh]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex cosh", "[cosh]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::cosh<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex cosh", "[cosh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::cosh(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::cosh<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::cosh<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/exp_complex.cpp
+++ b/tests/exp_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex exp", "[exp]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex exp", "[exp]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::exp<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex exp", "[exp]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::exp(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::exp<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::exp<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/log10_complex.cpp
+++ b/tests/log10_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex log10", "[log10]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex log10", "[log10]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::log10<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex log10", "[log10]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::log10(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::log10<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::log10<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/log_complex.cpp
+++ b/tests/log_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex log", "[log]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex log", "[log]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::log<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex log", "[log]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::log(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::log<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::log<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/norm_complex.cpp
+++ b/tests/norm_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex norm cmplx", "[norm]", double, float,
                    sycl::half) {
   using T = TestType;
@@ -74,6 +78,61 @@ TEMPLATE_TEST_CASE("Test complex norm deci", "[norm]",
   cplx_out[0] = sycl::ext::cplx::norm<X>(input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex norm", "[norm]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<T, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<sycl::marray<T, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::norm(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::norm<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::norm<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/pow_complex.cpp
+++ b/tests/pow_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex pow cplx-cplx overload", "[pow]", double,
                    float, sycl::half) {
   using T = TestType;
@@ -187,6 +191,243 @@ TEMPLATE_TEST_CASE("Test complex pow deci-cplx overload", "[pow]", double,
   cplx_out[0] = sycl::ext::cplx::pow<T>(deci_input, cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex pow cplx-cplx overload", "[pow]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  /* sycl::half cases are emulated with float for std::complex class (std_in) */
+  using X = typename std::conditional<std::is_same<T, sycl::half>::value, float,
+                                      T>::type;
+
+  // std::complex test cases
+  const auto std_in1 =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+  sycl::marray<std::complex<X>, NumElements> std_in2;
+  for (std::size_t i = 0; i < NumElements; i++) {
+    std_in2[i] = std::complex<X>{std_in1[i].real(), std_in1[i].imag()};
+  }
+
+  // sycl::complex test cases
+  const auto cplx_input1 =
+      GENERATE(sycl::marray<sycl::ext::cplx::complex<T>, NumElements>{
+          sycl::ext::cplx::complex<T>{1.0, 1.0},
+          sycl::ext::cplx::complex<T>{4.42, 2.02},
+          sycl::ext::cplx::complex<T>{-3, 3.5},
+          sycl::ext::cplx::complex<T>{4.0, -4.0},
+          sycl::ext::cplx::complex<T>{2.02, inf_val<T>},
+          sycl::ext::cplx::complex<T>{inf_val<T>, 4.42},
+          sycl::ext::cplx::complex<T>{inf_val<T>, nan_val<T>},
+          sycl::ext::cplx::complex<T>{2.02, 4.42},
+          sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},
+          sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},
+          sycl::ext::cplx::complex<T>{inf_val<T>, inf_val<T>},
+          sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},
+          sycl::ext::cplx::complex<T>{inf_val<T>, inf_val<T>},
+          sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},
+      });
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input2;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input2[i] = sycl::ext::cplx::complex<T>{cplx_input1[i].real(),
+                                                 cplx_input1[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::pow(std_in1[i], std_in2[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+     }).wait();
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 3);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+
+  check_results(*cplx_out, std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex pow cplx-deci overload", "[pow]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in1 =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+  const auto std_in2 = GENERATE(init_deci(sycl::marray<T, NumElements>{
+      1.0,
+      4.42,
+      -3,
+      4.0,
+      2.02,
+      inf_val<T>,
+      inf_val<T>,
+      2.02,
+      nan_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+  }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input1;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input1[i] =
+        sycl::ext::cplx::complex<T>{std_in1[i].real(), std_in1[i].imag()};
+  }
+  sycl::marray<T, NumElements> cplx_input2;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input2[i] = std_in2[i];
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::pow(std_in1[i], std_in2[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+     }).wait();
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 3);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+
+  check_results(*cplx_out, std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex pow deci-cplx overload", "[pow]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in1 = GENERATE(init_deci(sycl::marray<T, NumElements>{
+      1.0,
+      4.42,
+      -3,
+      4.0,
+      2.02,
+      inf_val<T>,
+      inf_val<T>,
+      2.02,
+      nan_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+  }));
+  const auto std_in2 =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<T, NumElements> cplx_input1;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input1[i] = std_in1[i];
+  }
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input2;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input2[i] =
+        sycl::ext::cplx::complex<T>{std_in2[i].real(), std_in2[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::pow(std_in1[i], std_in2[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+     }).wait();
+
+    check_results(*cplx_out, std_out, /*tol_multiplier*/ 3);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::pow<T>(cplx_input1, cplx_input2);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/proj_complex.cpp
+++ b/tests/proj_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex proj cmplx", "[proj]", double, float,
                    sycl::half) {
   using T = TestType;
@@ -75,6 +79,120 @@ TEMPLATE_TEST_CASE("Test complex proj deci", "[proj]",
   cplx_out[0] = sycl::ext::cplx::proj<X>(input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex proj cplx overload", "[proj]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::proj(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::proj<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::proj<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex proj deci overload", "[proj]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in = GENERATE(init_deci(sycl::marray<T, NumElements>{
+      1.0,
+      4.42,
+      -3,
+      4.0,
+      2.02,
+      inf_val<T>,
+      inf_val<T>,
+      2.02,
+      nan_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+      inf_val<T>,
+      nan_val<T>,
+  }));
+
+  // sycl::complex test cases
+  sycl::marray<T, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] = std_in[i];
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::proj(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::proj(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::proj(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/sin_complex.cpp
+++ b/tests/sin_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex sin", "[sin]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex sin", "[sin]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::sin<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex sin", "[sin]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::sin(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::sin<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::sin<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/sinh_complex.cpp
+++ b/tests/sinh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex sinh", "[sinh]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex sinh", "[sinh]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::sinh<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex sinh", "[sinh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::sinh(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::sinh<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::sinh<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/sqrt_complex.cpp
+++ b/tests/sqrt_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex sqrt", "[sqrt]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex sqrt", "[sqrt]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::sqrt<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex sqrt", "[sqrt]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::sqrt(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::sqrt<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::sqrt<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/tan_complex.cpp
+++ b/tests/tan_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex tan", "[tan]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex tan", "[tan]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::tan<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex tan", "[tan]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::tan(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::tan<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::tan<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/tanh_complex.cpp
+++ b/tests/tanh_complex.cpp
@@ -1,5 +1,9 @@
 #include "test_helper.hpp"
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPLEX TESTS
+////////////////////////////////////////////////////////////////////////////////
+
 TEMPLATE_TEST_CASE("Test complex tanh", "[tanh]", double, float, sycl::half) {
   using T = TestType;
 
@@ -35,6 +39,66 @@ TEMPLATE_TEST_CASE("Test complex tanh", "[tanh]", double, float, sycl::half) {
   cplx_out[0] = sycl::ext::cplx::tanh<T>(cplx_input);
 
   check_results(cplx_out[0], std_out);
+
+  sycl::free(cplx_out, Q);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex tanh", "[tanh]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 14), (float, 14), (sycl::half, 14)) {
+  sycl::queue Q;
+
+  // std::complex test cases
+  const auto std_in =
+      GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{
+          std::complex<T>{1.0, 1.0},
+          std::complex<T>{4.42, 2.02},
+          std::complex<T>{-3, 3.5},
+          std::complex<T>{4.0, -4.0},
+          std::complex<T>{2.02, inf_val<T>},
+          std::complex<T>{inf_val<T>, 4.42},
+          std::complex<T>{inf_val<T>, nan_val<T>},
+          std::complex<T>{2.02, 4.42},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+          std::complex<T>{inf_val<T>, inf_val<T>},
+          std::complex<T>{nan_val<T>, nan_val<T>},
+      }));
+
+  // sycl::complex test cases
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    cplx_input[i] =
+        sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};
+  }
+
+  sycl::marray<std::complex<T>, NumElements> std_out{};
+  auto *cplx_out = sycl::malloc_shared<
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);
+
+  // Get std::complex output
+  for (std::size_t i = 0; i < NumElements; ++i)
+    std_out[i] = std::tanh(std_in[i]);
+
+  // Check cplx::complex output from device
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       *cplx_out = sycl::ext::cplx::tanh<T>(cplx_input);
+     }).wait();
+
+    check_results(*cplx_out, std_out);
+  }
+
+  // Check cplx::complex output from host
+  *cplx_out = sycl::ext::cplx::tanh<T>(cplx_input);
+
+  check_results(*cplx_out, std_out);
 
   sycl::free(cplx_out, Q);
 }

--- a/tests/test_marray_complex_getters.cpp
+++ b/tests/test_marray_complex_getters.cpp
@@ -1,0 +1,77 @@
+#include "test_helper.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex real component marray", "[getter]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 8), (float, 8), (sycl::half, 8)) {
+  sycl::queue Q;
+
+  // Test cases
+  const auto init = GENERATE(sycl::marray<T, NumElements>{
+      0.0,
+      1.0,
+      4.42,
+      -0.0,
+      -1.0,
+      -4.42,
+      nan_val<T>,
+      inf_val<T>,
+  });
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    input[i] = sycl::ext::cplx::complex<T>{init[i], (T)0};
+  }
+
+  auto *out = sycl::malloc_shared<sycl::marray<T, NumElements>>(1, Q);
+
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() { *out = input.real(); }).wait();
+
+    check_results(*out, init);
+  }
+
+  *out = input.real();
+
+  check_results(*out, init);
+
+  sycl::free(out, Q);
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex imag component marray", "[getter]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 8), (float, 8), (sycl::half, 8)) {
+  sycl::queue Q;
+
+  // Test cases
+  const auto init = GENERATE(sycl::marray<T, NumElements>{
+      0.0,
+      1.0,
+      4.42,
+      -0.0,
+      -1.0,
+      -4.42,
+      nan_val<T>,
+      inf_val<T>,
+  });
+  sycl::marray<sycl::ext::cplx::complex<T>, NumElements> input;
+  for (std::size_t i = 0; i < NumElements; ++i) {
+    input[i] = sycl::ext::cplx::complex<T>{(T)0, init[i]};
+  }
+
+  auto *out = sycl::malloc_shared<sycl::marray<T, NumElements>>(1, Q);
+
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() { *out = input.imag(); }).wait();
+
+    check_results(*out, init);
+  }
+
+  *out = input.imag();
+
+  check_results(*out, init);
+
+  sycl::free(out, Q);
+}

--- a/tests/test_marray_complex_types.cpp
+++ b/tests/test_marray_complex_types.cpp
@@ -1,0 +1,353 @@
+#include "test_helper.hpp"
+
+using namespace sycl::ext::cplx;
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+// Define math function tests
+#define TEST_MATH_FUNC_TYPE(func)                                              \
+  template <typename T, std::size_t NumElements>                               \
+  auto test##_##func##_##types(sycl::queue &Q) {                               \
+    /* Check host code */                                                      \
+    static_assert(std::is_same_v<                                              \
+                  sycl::marray<complex<T>, NumElements>,                       \
+                  decltype(func(sycl::marray<complex<T>, NumElements>()))>);   \
+                                                                               \
+    /* Check device code */                                                    \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() {                                                    \
+         static_assert(                                                        \
+             std::is_same_v<sycl::marray<complex<T>, NumElements>,             \
+                            decltype(func(                                     \
+                                sycl::marray<complex<T>, NumElements>()))>);   \
+       }).wait();                                                              \
+    }                                                                          \
+  }
+
+TEST_MATH_FUNC_TYPE(acos)
+TEST_MATH_FUNC_TYPE(asin)
+TEST_MATH_FUNC_TYPE(atan)
+TEST_MATH_FUNC_TYPE(acosh)
+TEST_MATH_FUNC_TYPE(asinh)
+TEST_MATH_FUNC_TYPE(atanh)
+TEST_MATH_FUNC_TYPE(conj)
+TEST_MATH_FUNC_TYPE(cos)
+TEST_MATH_FUNC_TYPE(cosh)
+TEST_MATH_FUNC_TYPE(exp)
+TEST_MATH_FUNC_TYPE(log)
+TEST_MATH_FUNC_TYPE(log10)
+TEST_MATH_FUNC_TYPE(proj)
+TEST_MATH_FUNC_TYPE(sin)
+TEST_MATH_FUNC_TYPE(sinh)
+TEST_MATH_FUNC_TYPE(sqrt)
+TEST_MATH_FUNC_TYPE(tan)
+TEST_MATH_FUNC_TYPE(tanh)
+#undef TEST_MATH_FUNC_TYPE
+
+// Define math operations tests
+#define TEST_MATH_OP_TYPE(op_name, op)                                         \
+  template <typename T, std::size_t NumElements>                               \
+  auto test##_##op_name##_##types(sycl::queue &Q) {                            \
+    /* Check host code */                                                      \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<complex<T>, NumElements>,                             \
+            decltype(std::declval<sycl::marray<complex<T>, NumElements>>()     \
+                         op std::declval<                                      \
+                             sycl::marray<complex<T>, NumElements>>())>);      \
+                                                                               \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<complex<T>, NumElements>,                             \
+            decltype(std::declval<sycl::marray<complex<T>, NumElements>>()     \
+                         op std::declval<sycl::marray<T, NumElements>>())>);   \
+                                                                               \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<complex<T>, NumElements>,                             \
+            decltype(std::declval<sycl::marray<T, NumElements>>() op std::     \
+                         declval<sycl::marray<complex<T>, NumElements>>())>);  \
+                                                                               \
+    /* Check device code */                                                    \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() {                                                    \
+         static_assert(                                                        \
+             std::is_same_v<sycl::marray<complex<T>, NumElements>,             \
+                            decltype(std::declval<                             \
+                                     sycl::marray<complex<T>, NumElements>>()  \
+                                         op std::declval<sycl::marray<         \
+                                             complex<T>, NumElements>>())>);   \
+                                                                               \
+         static_assert(                                                        \
+             std::is_same_v<                                                   \
+                 sycl::marray<complex<T>, NumElements>,                        \
+                 decltype(std::declval<                                        \
+                          sycl::marray<complex<T>, NumElements>>() op          \
+                              std::declval<sycl::marray<T, NumElements>>())>); \
+                                                                               \
+         static_assert(                                                        \
+             std::is_same_v<                                                   \
+                 sycl::marray<complex<T>, NumElements>,                        \
+                 decltype(std::declval<sycl::marray<T, NumElements>>()         \
+                              op std::declval<                                 \
+                                  sycl::marray<complex<T>, NumElements>>())>); \
+       }).wait();                                                              \
+    }                                                                          \
+  }
+
+TEST_MATH_OP_TYPE(add, +)
+TEST_MATH_OP_TYPE(sub, -)
+TEST_MATH_OP_TYPE(mul, *)
+TEST_MATH_OP_TYPE(div, /)
+#undef TEST_MATH_FUNC_TYPE
+
+// Define math operations tests
+#define TEST_LOGIC_OP_TYPE(op_name, op)                                        \
+  template <typename T, std::size_t NumElements>                               \
+  auto test##_##op_name##_##types(sycl::queue &Q) {                            \
+    /* Check host code */                                                      \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<bool, NumElements>,                                   \
+            decltype(std::declval<sycl::marray<complex<T>, NumElements>>()     \
+                         op std::declval<                                      \
+                             sycl::marray<complex<T>, NumElements>>())>);      \
+                                                                               \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<bool, NumElements>,                                   \
+            decltype(std::declval<sycl::marray<complex<T>, NumElements>>()     \
+                         op std::declval<sycl::marray<T, NumElements>>())>);   \
+                                                                               \
+    static_assert(                                                             \
+        std::is_same_v<                                                        \
+            sycl::marray<bool, NumElements>,                                   \
+            decltype(std::declval<sycl::marray<T, NumElements>>() op std::     \
+                         declval<sycl::marray<complex<T>, NumElements>>())>);  \
+                                                                               \
+    /* Check device code */                                                    \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() {                                                    \
+         static_assert(                                                        \
+             std::is_same_v<sycl::marray<bool, NumElements>,                   \
+                            decltype(std::declval<                             \
+                                     sycl::marray<complex<T>, NumElements>>()  \
+                                         op std::declval<sycl::marray<         \
+                                             complex<T>, NumElements>>())>);   \
+                                                                               \
+         static_assert(                                                        \
+             std::is_same_v<                                                   \
+                 sycl::marray<bool, NumElements>,                              \
+                 decltype(std::declval<                                        \
+                          sycl::marray<complex<T>, NumElements>>() op          \
+                              std::declval<sycl::marray<T, NumElements>>())>); \
+                                                                               \
+         static_assert(                                                        \
+             std::is_same_v<                                                   \
+                 sycl::marray<bool, NumElements>,                              \
+                 decltype(std::declval<sycl::marray<T, NumElements>>()         \
+                              op std::declval<                                 \
+                                  sycl::marray<complex<T>, NumElements>>())>); \
+       }).wait();                                                              \
+    }                                                                          \
+  }
+
+TEST_LOGIC_OP_TYPE(eq, ==)
+TEST_LOGIC_OP_TYPE(inv_eq, !=)
+#undef TEST_LOGIC_OP_TYPE
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex abs function return types",
+                       "[marray types]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  static_assert(
+      std::is_same_v<sycl::marray<T, NumElements>,
+                     decltype(abs(sycl::marray<complex<T>, NumElements>()))>);
+
+  /* Check device code */
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       static_assert(std::is_same_v<
+                     sycl::marray<T, NumElements>,
+                     decltype(abs(sycl::marray<complex<T>, NumElements>()))>);
+     }).wait();
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex polar function return types",
+                       "[marray types]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  /* Check host code */
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(polar(sycl::marray<T, NumElements>()))>);
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(polar(sycl::marray<T, NumElements>(),
+                                    sycl::marray<T, NumElements>()))>);
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(polar(sycl::marray<T, NumElements>(), T()))>);
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(polar(T(), sycl::marray<T, NumElements>()))>);
+
+  /* Check device code */
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(polar(sycl::marray<T, NumElements>()))>);
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(polar(sycl::marray<T, NumElements>(),
+                                         sycl::marray<T, NumElements>()))>);
+       static_assert(std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                                    decltype(polar(
+                                        sycl::marray<T, NumElements>(), T()))>);
+       static_assert(std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                                    decltype(polar(
+                                        T(), sycl::marray<T, NumElements>()))>);
+     }).wait();
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG("Test marray complex pow function return types",
+                       "[marray types]",
+                       ((typename T, std::size_t NumElements), T, NumElements),
+                       (double, 10), (float, 10), (sycl::half, 10)) {
+  sycl::queue Q;
+
+  /* Check host code */
+  // complex-deci
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                  sycl::marray<T, NumElements>()))>);
+  static_assert(std::is_same_v<
+                sycl::marray<complex<T>, NumElements>,
+                decltype(pow(sycl::marray<complex<T>, NumElements>(), T()))>);
+  static_assert(std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                               decltype(pow(complex<T>(),
+                                            sycl::marray<T, NumElements>()))>);
+
+  // complex-complex
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                  complex<T>()))>);
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(complex<T>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+
+  // deci-complx
+  static_assert(
+      std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<T, NumElements>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+  static_assert(std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                               decltype(pow(sycl::marray<T, NumElements>(),
+                                            complex<T>()))>);
+  static_assert(std::is_same_v<
+                sycl::marray<complex<T>, NumElements>,
+                decltype(pow(T(), sycl::marray<complex<T>, NumElements>()))>);
+
+  /* Check device code */
+  if (is_type_supported<T>(Q)) {
+    Q.single_task([=]() {
+       // complex-deci
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                       sycl::marray<T, NumElements>()))>);
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                       T()))>);
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(pow(complex<T>(),
+                                       sycl::marray<T, NumElements>()))>);
+
+       // complex-complex
+       static_assert(std::is_same_v<
+                     sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(pow(sycl::marray<complex<T>, NumElements>(),
+                                       complex<T>()))>);
+       static_assert(std::is_same_v<
+                     sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(complex<T>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+
+       // deci-complx
+       static_assert(std::is_same_v<
+                     sycl::marray<complex<T>, NumElements>,
+                     decltype(pow(sycl::marray<T, NumElements>(),
+                                  sycl::marray<complex<T>, NumElements>()))>);
+       static_assert(std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                                    decltype(pow(sycl::marray<T, NumElements>(),
+                                                 complex<T>()))>);
+       static_assert(
+           std::is_same_v<sycl::marray<complex<T>, NumElements>,
+                          decltype(pow(
+                              T(), sycl::marray<complex<T>, NumElements>()))>);
+     }).wait();
+  }
+}
+
+#define TEST(func)                                                             \
+  TEMPLATE_TEST_CASE_SIG(                                                      \
+      "Test marray complex " #func " function return types", "[marray types]", \
+      ((typename T, std::size_t NumElements), T, NumElements), (double, 10),   \
+      (float, 10), (sycl::half, 10)) {                                         \
+    sycl::queue Q;                                                             \
+    test##_##func##_##types<T, NumElements>(Q);                                \
+  }
+
+TEST(acos)
+TEST(asin)
+TEST(atan)
+TEST(acosh)
+TEST(asinh)
+TEST(atanh)
+TEST(conj)
+TEST(cos)
+TEST(cosh)
+TEST(exp)
+TEST(log)
+TEST(log10)
+TEST(proj)
+TEST(sin)
+TEST(sinh)
+TEST(sqrt)
+TEST(tan)
+TEST(tanh)
+
+TEST(add)
+TEST(sub)
+TEST(mul)
+TEST(div)
+
+TEST(eq)
+TEST(inv_eq)
+#undef TEST

--- a/tests/test_operator_marray_complex.cpp
+++ b/tests/test_operator_marray_complex.cpp
@@ -1,0 +1,226 @@
+#include "test_helper.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS'S UTILITIES
+////////////////////////////////////////////////////////////////////////////////
+
+#define test_op(name, op)                                                      \
+  template <typename T, typename X, std::size_t NumElements>                   \
+  auto test##_##name(                                                          \
+      sycl::queue &Q,                                                          \
+      const sycl::marray<std::complex<X>, NumElements> &std_in1,               \
+      const sycl::marray<std::complex<X>, NumElements> &std_in2,               \
+      const sycl::marray<sycl::ext::cplx::complex<T>, NumElements>             \
+          &cplx_input1,                                                        \
+      const sycl::marray<sycl::ext::cplx::complex<T>, NumElements>             \
+          &cplx_input2) {                                                      \
+                                                                               \
+    sycl::marray<std::complex<T>, NumElements> std_out{};                      \
+    auto *cplx_out = sycl::malloc_shared<                                      \
+        sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);         \
+                                                                               \
+    /* Get std::complex output */                                              \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      std_out[i] = std_in1[i] op std_in2[i];                                   \
+                                                                               \
+    /* Check cplx::complex output from device */                               \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() { *cplx_out = cplx_input1 op cplx_input2; }).wait(); \
+      check_results(*cplx_out, std_out);                                       \
+    }                                                                          \
+                                                                               \
+    /* Check cplx::complex output from host */                                 \
+    *cplx_out = cplx_input1 op cplx_input2;                                    \
+                                                                               \
+    check_results(*cplx_out, std_out);                                         \
+                                                                               \
+    sycl::free(cplx_out, Q);                                                   \
+  }
+
+test_op(add, +);
+test_op(sub, -);
+test_op(mul, /);
+test_op(div, *);
+
+#undef test_op
+
+#define test_op_assign(name, op_assign)                                        \
+  template <typename T, typename X, std::size_t NumElements>                   \
+  auto test##_##name(                                                          \
+      sycl::queue &Q,                                                          \
+      const sycl::marray<std::complex<X>, NumElements> &std_in,                \
+      sycl::marray<std::complex<X>, NumElements> &std_inout,                   \
+      const sycl::marray<sycl::ext::cplx::complex<T>, NumElements>             \
+          &cplx_input1,                                                        \
+      sycl::marray<sycl::ext::cplx::complex<T>, NumElements> &cplx_input2) {   \
+                                                                               \
+    auto *cplx_inout = sycl::malloc_shared<                                    \
+        sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);         \
+    *cplx_inout = cplx_input2;                                                 \
+                                                                               \
+    /* Get std::complex output */                                              \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      std_inout[i] op_assign std_in[i];                                        \
+                                                                               \
+    /* Check cplx::complex output from device */                               \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() { *cplx_inout op_assign cplx_input1; }).wait();      \
+      check_results(*cplx_inout, convert_marray<T>(std_inout));                \
+    }                                                                          \
+                                                                               \
+    *cplx_inout = cplx_input2;                                                 \
+                                                                               \
+    /* Check cplx::complex output from host */                                 \
+    *cplx_inout op_assign cplx_input1;                                         \
+                                                                               \
+    check_results(*cplx_inout, convert_marray<T>(std_inout));                  \
+                                                                               \
+    sycl::free(cplx_inout, Q);                                                 \
+  }
+
+test_op_assign(add_assign, +=);
+test_op_assign(sub_assign, -=);
+test_op_assign(mul_assign, /=);
+test_op_assign(div_assign, *=);
+
+#undef test_op_assign
+
+////////////////////////////////////////////////////////////////////////////////
+// MARRAY<COMPLEX> TESTS
+////////////////////////////////////////////////////////////////////////////////
+
+#define TEST(func)                                                             \
+  TEMPLATE_TEST_CASE_SIG(                                                      \
+      "Test marray complex operator " #func, "[" #func "]",                    \
+      ((typename T, std::size_t NumElements), T, NumElements), (double, 14),   \
+      (float, 14), (sycl::half, 14)) {                                         \
+    sycl::queue Q;                                                             \
+                                                                               \
+    /* sycl::half cases are emulated with float for std::complex class         \
+     * (std_in) */                                                             \
+    using X = typename std::conditional<std::is_same<T, sycl::half>::value,    \
+                                        float, T>::type;                       \
+                                                                               \
+    /* std::complex test cases */                                              \
+    const auto std_in1 =                                                       \
+        GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{  \
+            std::complex<T>{1.0, 1.0},                                         \
+            std::complex<T>{4.42, 2.02},                                       \
+            std::complex<T>{-3, 3.5},                                          \
+            std::complex<T>{4.0, -4.0},                                        \
+            std::complex<T>{2.02, inf_val<T>},                                 \
+            std::complex<T>{inf_val<T>, 4.42},                                 \
+            std::complex<T>{inf_val<T>, nan_val<T>},                           \
+            std::complex<T>{2.02, 4.42},                                       \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{inf_val<T>, inf_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{inf_val<T>, inf_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+        }));                                                                   \
+    sycl::marray<std::complex<X>, NumElements> std_in2;                        \
+    for (std::size_t i = 0; i < NumElements; i++) {                            \
+      std_in2[i] = std::complex<X>{std_in1[i].real(), std_in1[i].imag()};      \
+    }                                                                          \
+                                                                               \
+    /* sycl::complex test cases */                                             \
+    const auto cplx_input1 =                                                   \
+        GENERATE(sycl::marray<sycl::ext::cplx::complex<T>, NumElements>{       \
+            sycl::ext::cplx::complex<T>{1.0, 1.0},                             \
+            sycl::ext::cplx::complex<T>{4.42, 2.02},                           \
+            sycl::ext::cplx::complex<T>{-3, 3.5},                              \
+            sycl::ext::cplx::complex<T>{4.0, -4.0},                            \
+            sycl::ext::cplx::complex<T>{2.02, inf_val<T>},                     \
+            sycl::ext::cplx::complex<T>{inf_val<T>, 4.42},                     \
+            sycl::ext::cplx::complex<T>{inf_val<T>, nan_val<T>},               \
+            sycl::ext::cplx::complex<T>{2.02, 4.42},                           \
+            sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},               \
+            sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},               \
+            sycl::ext::cplx::complex<T>{inf_val<T>, inf_val<T>},               \
+            sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},               \
+            sycl::ext::cplx::complex<T>{inf_val<T>, inf_val<T>},               \
+            sycl::ext::cplx::complex<T>{nan_val<T>, nan_val<T>},               \
+        });                                                                    \
+    sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input2;        \
+    for (std::size_t i = 0; i < NumElements; ++i) {                            \
+      cplx_input2[i] = sycl::ext::cplx::complex<T>{cplx_input1[i].real(),      \
+                                                   cplx_input1[i].imag()};     \
+    }                                                                          \
+                                                                               \
+    test##_##func<T, X, NumElements>(Q, std_in1, std_in2, cplx_input1,         \
+                                     cplx_input2);                             \
+  }
+
+TEST(add)
+TEST(sub)
+TEST(mul)
+TEST(div)
+
+TEST(add_assign)
+TEST(sub_assign)
+TEST(mul_assign)
+TEST(div_assign)
+
+#undef TEST
+
+#define test_unary_op(test_name, label, op)                                    \
+  TEMPLATE_TEST_CASE_SIG(                                                      \
+      test_name, label,                                                        \
+      ((typename T, std::size_t NumElements), T, NumElements), (double, 14),   \
+      (float, 14), (sycl::half, 14)) {                                         \
+    sycl::queue Q;                                                             \
+                                                                               \
+    /* std::complex test cases */                                              \
+    const auto std_in =                                                        \
+        GENERATE(init_std_complex(sycl::marray<std::complex<T>, NumElements>{  \
+            std::complex<T>{1.0, 1.0},                                         \
+            std::complex<T>{4.42, 2.02},                                       \
+            std::complex<T>{-3, 3.5},                                          \
+            std::complex<T>{4.0, -4.0},                                        \
+            std::complex<T>{2.02, inf_val<T>},                                 \
+            std::complex<T>{inf_val<T>, 4.42},                                 \
+            std::complex<T>{inf_val<T>, nan_val<T>},                           \
+            std::complex<T>{2.02, 4.42},                                       \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{inf_val<T>, inf_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+            std::complex<T>{inf_val<T>, inf_val<T>},                           \
+            std::complex<T>{nan_val<T>, nan_val<T>},                           \
+        }));                                                                   \
+                                                                               \
+    /* sycl::complex test cases */                                             \
+    sycl::marray<sycl::ext::cplx::complex<T>, NumElements> cplx_input;         \
+    for (std::size_t i = 0; i < NumElements; ++i) {                            \
+      cplx_input[i] =                                                          \
+          sycl::ext::cplx::complex<T>{std_in[i].real(), std_in[i].imag()};     \
+    }                                                                          \
+                                                                               \
+    sycl::marray<std::complex<T>, NumElements> std_out{};                      \
+    auto *cplx_out = sycl::malloc_shared<                                      \
+        sycl::marray<sycl::ext::cplx::complex<T>, NumElements>>(1, Q);         \
+                                                                               \
+    /* Get std::complex output */                                              \
+    for (std::size_t i = 0; i < NumElements; ++i)                              \
+      std_out[i] = op std_in[i];                                               \
+                                                                               \
+    /* Check cplx::complex output from device */                               \
+    if (is_type_supported<T>(Q)) {                                             \
+      Q.single_task([=]() { *cplx_out = op cplx_input; }).wait();              \
+                                                                               \
+      check_results(*cplx_out, std_out);                                       \
+    }                                                                          \
+                                                                               \
+    /* Check cplx::complex output from host */                                 \
+    *cplx_out = op cplx_input;                                                 \
+                                                                               \
+    check_results(*cplx_out, std_out);                                         \
+                                                                               \
+    sycl::free(cplx_out, Q);                                                   \
+  }
+
+test_unary_op("Test marray complex addition unary operator", "[add]", +);
+test_unary_op("Test marray complex subtraction unary operator", "[sub]", -);
+
+#undef test_unary_op


### PR DESCRIPTION
This PR adds the `marray<complex, N>` specialization. The `marray` complex specialization is added using a mixture of free functions and deleting non applicable operators. This causes the `marray` interface to deviate slightly for the original sycl interface. The `marray` class is added in the sycl namespace to allow for proper specialization.

This additionally adds tests for the operators, interface, and free functions.