### PR TITLE
Propagate change made to the intel/llvm repo

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -398,13 +398,16 @@ public:
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
       : __re_(__c.real()), __im_(__c.imag()) {}
 
+  template <class _Xp, class = std::enable_if<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      const std::complex<value_type> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
+      const std::complex<_Xp> &__c)
+      : __re_(static_cast<value_type>(__c.real())),
+        __im_(static_cast<value_type>(__c.imag())) {}
 
+  template <class _Xp, class = std::enable_if<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-  operator std::complex<value_type>() const {
-    return std::complex<value_type>(__re_, __im_);
+  operator std::complex<_Xp>() const {
+    return std::complex<_Xp>(static_cast<_Xp>(__re_), static_cast<_Xp>(__im_));
   }
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type real() const {

--- a/tests/test_complex_types.cpp
+++ b/tests/test_complex_types.cpp
@@ -115,3 +115,47 @@ TEST_FUNC_TYPE("Test complex imag deci - deci types", "[imag]", imag)
 TEST_FUNC_TYPE("Test complex conj cplx - deci types", "[conj]", conj)
 TEST_FUNC_TYPE("Test complex proj cplx - deci types", "[proj]", proj)
 #undef TEST_FUNC_TYPE
+
+TEST_CASE("Test std::complex to sycl::complex conversion", "[conversion]") {
+  auto complex_f = sycl::ext::cplx::complex<float>{42.f, 42.f};
+  auto complex_d = sycl::ext::cplx::complex<double>{42.f, 42.f};
+  auto complex_h = sycl::ext::cplx::complex<sycl::half>{42.f, 42.f};
+
+  {
+    auto f = static_cast<std::complex<float>>(complex_f);
+    auto d = static_cast<std::complex<double>>(complex_f);
+    auto h = static_cast<std::complex<sycl::half>>(complex_f);
+  }
+  {
+    auto f = static_cast<std::complex<float>>(complex_d);
+    auto d = static_cast<std::complex<double>>(complex_d);
+    auto h = static_cast<std::complex<sycl::half>>(complex_d);
+  }
+  {
+    auto f = static_cast<std::complex<float>>(complex_h);
+    auto d = static_cast<std::complex<double>>(complex_h);
+    auto h = static_cast<std::complex<sycl::half>>(complex_h);
+  }
+}
+
+TEST_CASE("Test sycl::complex constructor from std::complex", "[constructor]") {
+  auto complex_f = std::complex<float>{42.f, 42.f};
+  auto complex_d = std::complex<double>{42.f, 42.f};
+  auto complex_h = std::complex<sycl::half>{42.f, 42.f};
+
+  {
+    sycl::ext::cplx::complex<float> f{complex_f};
+    sycl::ext::cplx::complex<double> d{complex_f};
+    sycl::ext::cplx::complex<sycl::half> h{complex_f};
+  }
+  {
+    sycl::ext::cplx::complex<float> f{complex_d};
+    sycl::ext::cplx::complex<double> d{complex_d};
+    sycl::ext::cplx::complex<sycl::half> h{complex_d};
+  }
+  {
+    sycl::ext::cplx::complex<float> f{complex_h};
+    sycl::ext::cplx::complex<double> d{complex_h};
+    sycl::ext::cplx::complex<sycl::half> h{complex_h};
+  }
+}


### PR DESCRIPTION
This PR update the constructor and conversion operator from and to std::complex.

One comment in the intel/llvm PR https://github.com/intel/llvm/pull/8068 has been made regarding the possibility to do:
```
std::complex<double> X = sycl::ext::oneapi::experimental::complex<float>{...};
```

The complex constructor and conversion operator have been modified in consequence to handle that behaviour.

After the PR got validated and merged, here's the PR to mirror the intel/llvm complex's interface 