### PR TITLE
Add block list for fast-math

### DIFF
--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -122,7 +122,7 @@ public:
 
     constexpr complex(double re = 0.0, double im = 0.0);
     constexpr complex(const complex<sycl::half>&);
-    constexpr complex(const cfomplex<float>&);
+    constexpr complex(const fomplex<float>&);
 
     constexpr complex(const std::complex<double>&);
     constexpr operator std::complex<double>();

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -274,7 +274,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_MARRAY_END_NAMESPACE }
 
 #if (defined(__FAST_MATH__) || defined(_M_FP_FAST)) &&                         \
-    !define(_NO_SYCL_EXT_CPLX_FAST_MATH)
+    !defined(_NO_SYCL_EXT_CPLX_FAST_MATH)
 #define _SYCL_EXT_CPLX_FAST_MATH
 #endif
 

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -122,7 +122,7 @@ public:
 
     constexpr complex(double re = 0.0, double im = 0.0);
     constexpr complex(const complex<sycl::half>&);
-    constexpr complex(const complex<float>&);
+    constexpr complex(const cfomplex<float>&);
 
     constexpr complex(const std::complex<double>&);
     constexpr operator std::complex<double>();
@@ -273,7 +273,8 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_MARRAY_BEGIN_NAMESPACE namespace _SYCL_MARRAY_NAMESPACE {
 #define _SYCL_MARRAY_END_NAMESPACE }
 
-#if ( defined(__FAST_MATH__) || defined(_M_FP_FAST) ) && !define(_NO_SYCL_EXT_CPLX_FAST_MATH)
+#if ( defined(__FAST_MATH__) || defined(_M_FP_FAST) ) && \
+    !define(_NO_SYCL_EXT_CPLX_FAST_MATH)
 #define _SYCL_EXT_CPLX_FAST_MATH
 #endif
 

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -273,7 +273,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_MARRAY_BEGIN_NAMESPACE namespace _SYCL_MARRAY_NAMESPACE {
 #define _SYCL_MARRAY_END_NAMESPACE }
 
-#if defined(__FAST_MATH__) || defined(_M_FP_FAST)
+#if ( defined(__FAST_MATH__) || defined(_M_FP_FAST) ) && !define(_NO_SYCL_EXT_CPLX_FAST_MATH)
 #define _SYCL_EXT_CPLX_FAST_MATH
 #endif
 

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -122,7 +122,7 @@ public:
 
     constexpr complex(double re = 0.0, double im = 0.0);
     constexpr complex(const complex<sycl::half>&);
-    constexpr complex(const fomplex<float>&);
+    constexpr complex(const complex<float>&);
 
     constexpr complex(const std::complex<double>&);
     constexpr operator std::complex<double>();

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -313,13 +313,11 @@ template <class _Tp> struct __numeric_type {
   static const bool value = !std::is_same<type, void>::value;
 };
 
-template <> struct __numeric_type<void> {
-  static const bool value = true;
-};
+template <> struct __numeric_type<void> { static const bool value = true; };
 
 template <class _A1, class _A2 = void, class _A3 = void,
-          bool = __numeric_type<_A1>::value && __numeric_type<_A2>::value &&
-                 __numeric_type<_A3>::value>
+          bool = __numeric_type<_A1>::value &&__numeric_type<_A2>::value
+              &&__numeric_type<_A3>::value>
 class __promote_imp {
 public:
   static const bool value = false;

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -273,7 +273,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 #define _SYCL_MARRAY_BEGIN_NAMESPACE namespace _SYCL_MARRAY_NAMESPACE {
 #define _SYCL_MARRAY_END_NAMESPACE }
 
-#if ( defined(__FAST_MATH__) || defined(_M_FP_FAST) ) && \
+#if (defined(__FAST_MATH__) || defined(_M_FP_FAST)) &&                         \
     !define(_NO_SYCL_EXT_CPLX_FAST_MATH)
 #define _SYCL_EXT_CPLX_FAST_MATH
 #endif
@@ -313,11 +313,13 @@ template <class _Tp> struct __numeric_type {
   static const bool value = !std::is_same<type, void>::value;
 };
 
-template <> struct __numeric_type<void> { static const bool value = true; };
+template <> struct __numeric_type<void> {
+  static const bool value = true;
+};
 
 template <class _A1, class _A2 = void, class _A3 = void,
-          bool = __numeric_type<_A1>::value &&__numeric_type<_A2>::value
-              &&__numeric_type<_A3>::value>
+          bool = __numeric_type<_A1>::value && __numeric_type<_A2>::value &&
+                 __numeric_type<_A3>::value>
 class __promote_imp {
 public:
   static const bool value = false;
@@ -359,7 +361,8 @@ class __promote : public __promote_imp<_A1, _A2, _A3> {};
 // without this extra help.
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isnan(const T a) {
-#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISNAN)
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) &&                                       \
+    !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISNAN)
   return false;
 #else
   return sycl::isnan(a);
@@ -368,7 +371,8 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isnan(const T a) {
 
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isfinite(const T a) {
-#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISFINITE)
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) &&                                       \
+    !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISFINITE)
   return true;
 #else
   return sycl::isfinite(a);
@@ -377,7 +381,8 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isfinite(const T a) {
 
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isinf(const T a) {
-#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISINF)
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) &&                                       \
+    !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISINF)
   return false;
 #else
   return sycl::isinf(a);
@@ -637,7 +642,8 @@ public:
   }
 
   operator/(const _complex<value_type> &__z, const _complex<value_type> &__w) {
-#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_DIV)
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) &&                                       \
+    !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_DIV)
     // This implementation is around 20% faster for single precision, 5% for
     // double, at the expense of larger error in some cases, because no scaling
     // is done.

--- a/include/sycl_ext_complex.hpp
+++ b/include/sycl_ext_complex.hpp
@@ -358,7 +358,7 @@ class __promote : public __promote_imp<_A1, _A2, _A3> {};
 // without this extra help.
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isnan(const T a) {
-#ifdef _SYCL_EXT_CPLX_FAST_MATH
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISNAN)
   return false;
 #else
   return sycl::isnan(a);
@@ -367,7 +367,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isnan(const T a) {
 
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isfinite(const T a) {
-#ifdef _SYCL_EXT_CPLX_FAST_MATH
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISFINITE)
   return true;
 #else
   return sycl::isfinite(a);
@@ -376,7 +376,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isfinite(const T a) {
 
 template <typename T>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool isinf(const T a) {
-#ifdef _SYCL_EXT_CPLX_FAST_MATH
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_ISINF)
   return false;
 #else
   return sycl::isinf(a);
@@ -636,7 +636,7 @@ public:
 
   _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
   operator/(const complex<value_type> &__z, const complex<value_type> &__w) {
-#if defined(_SYCL_EXT_CPLX_FAST_MATH)
+#if defined(_SYCL_EXT_CPLX_FAST_MATH) && !defined(_NO_SYCL_EXT_CPLX_FAST_MATH_DIV)
     // This implementation is around 20% faster for single precision, 5% for
     // double, at the expense of larger error in some cases, because no scaling
     // is done.


### PR DESCRIPTION
@nscottnichols  have a problem where enable -fast-math and sycl-complex broke his code.
This is due to our `div` algorithm. But we still need `-fast-math` to isnan, and other to get good performance